### PR TITLE
Filter the link returned in the WP API users response.

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -60,5 +60,9 @@ function bp_rest_api_endpoints() {
 		$controller = new BP_REST_Groups_Endpoint();
 		$controller->register_routes();
 	}
+
+	// Member response filters
+	require_once( dirname( __FILE__ ) . '/includes/bp-members/bp-members-filters.php' );
+
 }
 add_action( 'bp_rest_api_init', 'bp_rest_api_endpoints' );

--- a/includes/bp-members/bp-members-filters.php
+++ b/includes/bp-members/bp-members-filters.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * BP REST API Members Filters.
+ *
+ * @package BP REST
+ * @subpackage MembersFilters
+ * @since 1.0.0
+ */
+
+/**
+ * Replace the standard WP "author" link with a link to the BuddyPress user domain.
+ *
+ * @param WP_REST_Response $response  The response object.
+ * @param object           $user      User object used to create response.
+ * @param WP_REST_Request  $request   Request object.
+ */
+function bp_rest_filter_user_link( $response, $user, $request ) {
+  	if ( $user->ID ) {
+  		$response->data['link'] = bp_core_get_user_domain( $user->ID );
+  	}
+
+	return $response;
+}
+add_filter( 'rest_prepare_user', 'bp_rest_filter_user_link', 10, 3 );


### PR DESCRIPTION
Replace the standard WP "author" link with a link to the BuddyPress user domain.