### PR TITLE
Fix Activity delete permission failing unittest

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -532,7 +532,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		if ( false === $this->can_see( $request, true ) ) {
+		if ( ! bp_activity_user_can_delete( $activity ) ) {
 			return new WP_Error( 'rest_user_cannot_delete_activity',
 				__( 'Sorry, you cannot delete the activity.', 'buddypress' ),
 				array(

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -19,6 +19,10 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 			'role'          => 'administrator',
 			'user_email'    => 'admin@example.com',
 		) );
+
+		if ( ! $this->server ) {
+			$this->server = rest_get_server();
+		}
 	}
 
 	public function test_register_routes() {
@@ -283,12 +287,14 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * @group delete_item
+	 * @group imath
 	 */
 	public function test_delete_item_without_permission() {
-		$u = $this->factory->user->create();
-		wp_set_current_user( $u );
+		$u           = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$activity_id = $this->bp_factory->activity->create( array( 'user_id' => $u ) );
 
-		$activity_id  = $this->bp_factory->activity->create();
+		$u2 = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $u2 );
 
 		$activity = $this->endpoint->get_activity_object( $activity_id );
 		$this->assertEquals( $activity_id, $activity->id );

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -42,6 +42,10 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$this->endpoint     = new BP_REST_Members_Endpoint();
 		$this->endpoint_url = '/buddypress/v1/members';
+
+		if ( ! $this->server ) {
+			$this->server = rest_get_server();
+		}
 	}
 
 	public function test_register_routes() {


### PR DESCRIPTION
Hi @renatonascalves 

I will play around with the BP Rest API. So here's my first contribution :)

Unittest fix + fixes the fact `BP_REST_Activity_Endpoint->delete_item_permissions_check()` is too permissive as any logged in user could delete any activity item.