### PR TITLE
Improve the BP_REST_Activity_Endpoint->show_hidden() method

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -120,11 +120,13 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			$args['filter']['primary_id'] = $item_id;
 
 			/**
+			 * Make sure the Item ID is an integer.
+			 *
 			 * @todo Check why the primary_id default's value is an array
 			 *       in $this->get_collection_params()?
 			 */
 			if ( is_array( $item_id ) ) {
-				$item_id = reset( $item_id );
+				$item_id = (int) reset( $item_id );
 			}
 		}
 
@@ -792,7 +794,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			if ( groups_is_user_admin( $user_id, $item_id ) || groups_is_user_mod( $user_id, $item_id ) ) {
 				$retval = true;
 
-			// User is a member of the group.
+				// User is a member of the group.
 			} elseif ( (bool) groups_is_user_member( $user_id, $item_id ) ) {
 				$retval = true;
 			}
@@ -995,7 +997,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                       = parent::get_collection_params();
 		$params['context']['default'] = 'view';
 
 		$params['exclude'] = array(

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -6,6 +6,7 @@
  * @since 0.1.0
  */
 defined( 'ABSPATH' ) || exit;
+
 /**
  * Notifications endpoints.
  *


### PR DESCRIPTION
This method is used in the get_items() one to know if hide_sitewide activities should be fetched for the loggedin user.
1. As the default value of the primary id is an array, in order to avoid errors when checking if the user is a member/admin/mod of the group we need to extract the first value of this array.
2. Public Groups activities should be fetchable for any logged in user
3. A filter makes it possible for custom components to add their own logic about the hide_sitewide param.
4. If statements have been reorganized to avoid unnecessary checks.
5. bp_loggedin_user_id() does not seem to be set during a REST API request, get_current_user_id() is.