### PR TITLE
The user_login is a required field to insert a new user.

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -283,6 +283,25 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	}
 
 	/**
+	 * Prepares a single user for creation or update.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return object $prepared_user User object.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$prepared_user = parent::prepare_item_for_database( $request );
+
+		// The parent class uses username instead of user_login.
+		if ( ! isset( $prepared_user->user_login ) && $request['user_login'] ) {
+			$prepared_user->user_login = $request['user_login'];
+		}
+
+		return $prepared_user;
+	}
+
+	/**
 	 * Get the plugin schema, conforming to JSON Schema.
 	 *
 	 * @since 0.1.0
@@ -332,8 +351,9 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'description' => __( 'An alphanumeric identifier for the member.', 'buddypress' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'required'    => true,
 					'arg_options' => array(
-						'sanitize_callback' => array( $this, 'sanitize_slug' ),
+						'sanitize_callback' => array( $this, 'check_username' ),
 					),
 				),
 

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -146,9 +146,10 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$user );
 
 		$params = array(
-			'password' => 'testpassword',
-			'email'    => 'test@example.com',
-			'name'     => 'Test User',
+			'password'   => 'testpassword',
+			'email'      => 'test@example.com',
+			'user_login' => 'testuser',
+			'name'       => 'Test User',
 		);
 
 		$request = new WP_REST_Request( 'POST', $this->endpoint_url );


### PR DESCRIPTION
The BP_REST_Members_Endpoint class extends the WP_REST_Users_Controller one but has a different item schema. In particular, it uses an unrequired user_login key where the parent is using a required username key. As a result creating an item is generating a PHP error in the wp_insert_user() function at line 1526.
The fix is making the user_login key required, and extends the prepare_item_for_database() method so that the user_login is successfully prepared.