### PR TITLE
Add Response headers about total number of activities and pages

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -49,6 +49,8 @@ add_action( 'bp_rest_api_init', function() {
 		return;
 	}
 
+	require_once dirname( __FILE__ ) . '/includes/functions.php';
+
 	if ( bp_is_active( 'activity' ) ) {
 		require_once( dirname( __FILE__ ) . '/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php' );
 		$controller = new BP_REST_Activity_Endpoint();

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -79,7 +79,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @since 0.1.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Request List of activities object data.
+	 * @return WP_REST_Response List of activities response data.
 	 */
 	public function get_items( $request ) {
 		$args = array(
@@ -141,7 +141,16 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$retval = rest_ensure_response( $retval );
+		$response = rest_ensure_response( $retval );
+
+		// Set headers to let the Client Script be aware of the pagination.
+		if ( ! empty( $activities['total'] ) && $args['per_page'] ) {
+			$total_activities = (int) $activities['total'];
+			$max_pages        = ceil( $total_activities / (int) $args['per_page'] );
+
+			$response->header( 'X-WP-Total', (int) $total_activities );
+			$response->header( 'X-WP-TotalPages', (int) $max_pages );
+		}
 
 		/**
 		 * Fires after a list of activities is fetched via the REST API.
@@ -149,12 +158,12 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		 * @since 0.1.0
 		 *
 		 * @param object           $activities Fetched activities.
-		 * @param WP_REST_Response $retval   The response data.
-		 * @param WP_REST_Request  $request  The request sent to the API.
+		 * @param WP_REST_Response $response   The response data.
+		 * @param WP_REST_Request  $request    The request sent to the API.
 		 */
-		do_action( 'rest_activity_get_items', $activities, $retval, $request );
+		do_action( 'rest_activity_get_items', $activities, $response, $request );
 
-		return $retval;
+		return $response;
 	}
 
 	/**

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -142,15 +142,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $retval );
-
-		// Set headers to let the Client Script be aware of the pagination.
-		if ( ! empty( $activities['total'] ) && $args['per_page'] ) {
-			$total_activities = (int) $activities['total'];
-			$max_pages        = ceil( $total_activities / (int) $args['per_page'] );
-
-			$response->header( 'X-WP-Total', (int) $total_activities );
-			$response->header( 'X-WP-TotalPages', (int) $max_pages );
-		}
+		$response = bp_rest_response_add_total_headers( $response, $activities['total'], $args['per_page'] );
 
 		/**
 		 * Fires after a list of activities is fetched via the REST API.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * BP REST: common functions.
+ *
+ * @package BuddyPress
+ * @since 0.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Set headers to let the Client Script be aware of the pagination.
+ *
+ * @since 0.1.0
+ *
+ * @param  WP_REST_Response $response The response data.
+ * @param  integer          $total    The total number of found items.
+ * @param  integer          $per_page The number of items per page of results.
+ * @return WP_REST_Response $response The response data.
+ */
+function bp_rest_response_add_total_headers( WP_REST_Response $response, $total = 0, $per_page = 0 ) {
+	if ( ! $total || ! $per_page ) {
+		return $response;
+	}
+
+	$total_items = (int) $total;
+	$max_pages   = ceil( $total_items / (int) $per_page );
+
+	$response->header( 'X-WP-Total', $total_items );
+	$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+	return $response;
+}


### PR DESCRIPTION
Client scripts need to be informed about the total amount of activities found for the request and about the total amount of available pages for the results of the request. Otherwise building a pagination is not possible and it needs the script to keep on requesting untill the response returns no results.
To avoid altering the response data with these two piece of informations, I suggest to use the allowed headers made available by the WordPress REST API :
- X-WP-Total is informing about the total amount of activities found.
- X-WP-TotalPages is informing about the number of pages.