### PR TITLE
Activities need to be rendered

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,4 +12,7 @@
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<php>
+        <const name="SCRIPT_DEBUG" value="0" />
+    </php>
 </phpunit>


### PR DESCRIPTION
Instead of having the raw data fetched into the view context, I think we should provide rendered activities into this context and provide both (raw data + rendered activity) into the edit context.
In other words, we need to make sure the activity content filters are fired to sanitize the output/run formatting filters when the context is a view one.
I suggest to do just like WordPress does for the Post Types : using an object type for the content key of the schema with raw and rendered properties.
From the client side, developers will need to update their scripts to display the content and use data.content.rendered instead of data.content for instance.

FYI I've added a test about embeds into activity content, to avoid a fatal error now WordPress is using a build/src architecture I've edited the phpunit.xml.dist file to make sure the `SCRIPT_DEBUG` constant is false. As we are not testing JavaScript, I don't think it's a problem.