### PR TITLE
Add Activity favorites

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Please use and provide feedback!
 
 ## Endpoints (Components) Under Consideration
 
-- Activity Favorites
 - Group Invites
 - Group Members
 - Settings

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -21,8 +21,9 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @since 0.1.0
 	 */
 	public function __construct() {
-		$this->namespace = 'buddypress/v1';
-		$this->rest_base = buddypress()->activity->id;
+		$this->namespace      = 'buddypress/v1';
+		$this->rest_base      = buddypress()->activity->id;
+		$this->user_favorites = array();
 	}
 
 	/**
@@ -47,7 +48,9 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			'schema' => array( $this, 'get_item_schema' ),
 		) );
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+		$activity_endpoint = '/' . $this->rest_base . '/(?P<id>[\d]+)';
+
+		register_rest_route( $this->namespace, $activity_endpoint, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
@@ -68,6 +71,16 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'delete_item' ),
 				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_item_schema' ),
+		) );
+
+		// Register the favorite route.
+		register_rest_route( $this->namespace, $activity_endpoint . '/favorite', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_favorite' ),
+				'permission_callback' => array( $this, 'update_favorite_permissions_check' ),
 			),
 			'schema' => array( $this, 'get_item_schema' ),
 		) );
@@ -202,6 +215,25 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks if the current user is logged in and set their favorites.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return boolean True if the user is logged in. False otherwise.
+	 */
+	public function get_user_permission_check() {
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		// Current user favorites.
+		$user_favorites       = bp_activity_get_user_favorites( get_current_user_id() );
+		$this->user_favorites = array_filter( wp_parse_id_list( $user_favorites ) );
+
+		return true;
+	}
+
+	/**
 	 * Check if a given request has access to get information about a specific activity.
 	 *
 	 * @since 0.1.0
@@ -210,6 +242,15 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @return WP_Error|bool
 	 */
 	public function get_item_permissions_check( $request ) {
+		if ( ! $this->get_user_permission_check() ) {
+			return new WP_Error( 'rest_authorization_required',
+				__( 'Sorry, you are not allowed to see the activity.', 'buddypress' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
 		if ( ! $this->can_see( $request ) ) {
 			return new WP_Error( 'rest_user_cannot_view_activity',
 				__( 'Sorry, you cannot view the activities.', 'buddypress' ),
@@ -240,7 +281,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @return WP_Error|bool
 	 */
 	public function get_items_permissions_check( $request ) {
-		if ( ! is_user_logged_in() ) {
+		if ( ! $this->get_user_permission_check() ) {
 			return new WP_Error( 'rest_authorization_required',
 				__( 'Sorry, you are not allowed to see the activities.', 'buddypress' ),
 				array(
@@ -558,6 +599,108 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
+	 * Adds or removes the activity from the current user's favorites.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_favorite( $request ) {
+		$activity = $this->get_activity_object( $request );
+		$user_id  = get_current_user_id();
+
+		$result = false;
+		if ( in_array( $activity->id, $this->user_favorites, true ) ) {
+			$result  = bp_activity_remove_user_favorite( $activity->id, $user_id );
+			$message = __( 'Sorry, you cannot remove the activity from your favorites.', 'buddypress' );
+
+			// Update the user favorites, removing the activity ID.
+			$this->user_favorites = array_diff( $this->user_favorites, array( $activity->id ) );
+		} else {
+			$result = bp_activity_add_user_favorite( $activity->id, $user_id );
+			$message = __( 'Sorry, you cannot add the activity to your favorites.', 'buddypress' );
+
+			// Update the user favorites, adding the activity ID.
+			$this->user_favorites[] = (int) $activity->id;
+		}
+
+		if ( ! $result ) {
+			return new WP_Error( 'rest_user_cannot_update_activity_favorite',
+				$message,
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		// Prepare the response now the user favorites has been updated.
+		$retval = array(
+			$this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $activity, $request )
+			),
+		);
+
+		$response = rest_ensure_response( $retval );
+
+		/**
+		 * Fires after user favorited activities has been updated via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param object           $activity       The updated activity.
+		 * @param array            $user_favorites The updated user favorites.
+		 * @param WP_REST_Response $response       The response data.
+		 * @param WP_REST_Request  $request        The request sent to the API.
+		 */
+		do_action( 'rest_activity_update_favorite', $activity, $this->user_favorites, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to update user favorites.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function update_favorite_permissions_check( $request ) {
+		// Bail early.
+		if ( ! $this->get_user_permission_check() ) {
+			return new WP_Error( 'rest_authorization_required',
+				__( 'Sorry, you need to be logged in to update your favorites.', 'buddypress' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		if ( ! bp_activity_can_favorite() ) {
+			return new WP_Error( 'rest_activity_cannot_favorite',
+				__( 'Sorry, Activities cannot be favorited.', 'buddypress' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		$activity = $this->get_activity_object( $request );
+
+		if ( empty( $activity->id ) ) {
+			return new WP_Error( 'rest_activity_invalid_id',
+				__( 'Invalid activity id.', 'buddypress' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Renders the content of an activity.
 	 *
 	 * @since 0.1.0
@@ -629,6 +772,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			'status'                => $activity->is_spam ? 'spam' : 'published',
 			'title'                 => $activity->action,
 			'type'                  => $activity->type,
+			'favorited'             => in_array( $activity->id, $this->user_favorites, true ),
 		);
 
 		$schema = $this->get_item_schema();
@@ -824,6 +968,12 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( 'activity_comment' === $activity->type ) {
 			$links['up'] = array(
 				'href' => rest_url( $url ),
+			);
+		}
+
+		if ( bp_activity_can_favorite() ) {
+			$links['favorite'] = array(
+				'href' => rest_url( $url . '/favorite' ),
 			);
 		}
 
@@ -1051,6 +1201,13 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 					'context'     => array( 'edit' ),
 					'description' => __( 'Whether the activity object should be sitewide hidden or not.', 'buddypress' ),
 					'type'        => 'boolean',
+				),
+
+				'favorited'             => array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'Whether the activity object has been favorited by the current user.', 'buddypress' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
 				),
 			),
 		);

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -679,7 +679,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 
 		if ( ! bp_activity_can_favorite() ) {
 			return new WP_Error( 'rest_activity_cannot_favorite',
-				__( 'Sorry, Activities cannot be favorited.', 'buddypress' ),
+				__( 'Sorry, Activity cannot be favorited.', 'buddypress' ),
 				array(
 					'status' => 500,
 				)


### PR DESCRIPTION
The idea is to implement it a bit differently than how it is done in AJAX. The user is updating their favorites for a specific activity Rest request.
When fetching activities so that it is easy for a client to know whether an activity is favorited or not, i have updated the schema with a readonly property (favorited).
I am only getting the user favorites for get_items/get_item and update_favorite methods as i dont think we need it elsewhere