### PR TITLE
Don't modify core /users/ query results.

### DIFF
--- a/includes/bp-members/bp-members-filters.php
+++ b/includes/bp-members/bp-members-filters.php
@@ -22,6 +22,10 @@ defined( 'ABSPATH' ) || exit;
  * @return array
  */
 function bp_remove_has_published_posts_from_wp_api_user_query( $prepared_args, $request ) {
+	if ( 0 !== strpos( $request->get_route(), '/buddypress/v1/members' ) ) {
+		return $prepared_args;
+	}
+
 	unset( $prepared_args['has_published_posts'] );
 
 	return $prepared_args;


### PR DESCRIPTION
The `bp_remove_has_published_posts_from_wp_api_user_query()` filter affects *all* API queries. This feels like unexpected behavior to me. IMO we should be more conservative here, only modifying the query if we know it's the BP `/members/` query.

First question is whether you agree with me about this. I don't have a really great argument :-D But, if I were building an external client that fetched a list of users at `/users/`, I'd expect to be able to use the `has_published_posts` param whether or not BP was involved.

Second question is how to implement. In this PR I specified the `/members/` endpoint, but if we extend the core `users` query elsewhere in BP-REST, then we might want to make it more general. The hardcoding of the namespace, version number, and `rest_base` also seem wrong to me - we might want these defined in a central location, both to be DRY and also to make them filterable (for whitelabeling, etc). See eg https://github.com/buddypress/BP-REST/issues/29#issuecomment-234601617