### PR TITLE
Activity show hidden

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -594,7 +594,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				$user_favorites       = bp_activity_get_user_favorites( get_current_user_id() );
 				$this->user_favorites = array_filter( wp_parse_id_list( $user_favorites ) );
 			} else {
-				$user_favorites = array();
+				$this->user_favorites = array();
 			}
 		}
 

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -214,16 +214,6 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	public function get_item( $request ) {
 		$activity = $this->get_activity_object( $request );
 
-		// Prevent non-members from seeing hidden activity.
-		if ( ! $this->show_hidden( $activity->component, $activity->item_id ) ) {
-			return new WP_Error( 'bp_rest_invalid_activity',
-				__( 'Invalid activity id.', 'buddypress' ),
-				array(
-					'status' => 404,
-				)
-			);
-		}
-
 		$retval = array(
 			$this->prepare_response_for_collection(
 				$this->prepare_item_for_response( $activity, $request )


### PR DESCRIPTION
Currently, if you have an activity item tied to a public group, it's not possible to query for that item unless you're a member of that group. This incorrect behavior is caused by https://github.com/buddypress/BP-REST/blob/b639328eb5ad319b60c30951f7ef1b644a8ff25d/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php#L217

There are two problems with the check here. One is that it doesn't cover the case of public groups. The other is that it's redundant: `get_item_permissions_check()` happens before, and calls `can_see()`; this, in turn, calls `bp_activity_can_read()`, which does a (more thorough) group membership check. I've included a test that verifies this.