### PR TITLE
Updated URI format for group member endpoint.

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-members-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-members-endpoint.php
@@ -388,7 +388,7 @@ class BP_REST_Group_Members_Endpoint extends WP_REST_Controller {
 	public function delete_item_permissions_check( $request ) {
 		if ( ! is_user_logged_in() ) {
 			return new WP_Error( 'bp_rest_authorization_required',
-				__( 'Sorry, you need to be logged in to make an update.', 'buddypress' ),
+				__( 'Sorry, you need to be logged in to delete a group membership.', 'buddypress' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)

--- a/includes/bp-groups/classes/class-bp-rest-group-members-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-members-endpoint.php
@@ -40,7 +40,7 @@ class BP_REST_Group_Members_Endpoint extends WP_REST_Controller {
 	 */
 	public function __construct() {
 		$this->namespace        = 'buddypress/v1';
-		$this->rest_base        = 'group/members';
+		$this->rest_base        = 'groups';
 		$this->groups_endpoint  = new BP_REST_Groups_Endpoint();
 		$this->members_endpoint = new BP_REST_Members_Endpoint();
 	}
@@ -51,17 +51,26 @@ class BP_REST_Group_Members_Endpoint extends WP_REST_Controller {
 	 * @since 0.1.0
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<group_id>[\d]+)/members', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'                => $this->get_collection_params(),
 			),
+			'schema' => array( $this, 'get_item_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<group_id>[\d]+)/members/(?P<user_id>[\d]+)', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => $this->get_update_collection_params(),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
 				'args'                => $this->get_update_collection_params(),
 			),
 			'schema' => array( $this, 'get_item_schema' ),
@@ -292,20 +301,6 @@ class BP_REST_Group_Members_Endpoint extends WP_REST_Controller {
 						return true;
 					}
 
-				case 'remove' :
-					// Users may not leave group if it'll leave the group without an admin.
-					$group_admins = groups_get_group_admins( $group->id );
-					if ( 1 === count( $group_admins ) && $loggedin_user_id === $group_admins[0]->user_id && $user->ID === $loggedin_user_id ) {
-						return new WP_Error( 'bp_rest_group_member_cannot_remove',
-							__( 'Sorry, you are not allowed to leave this group.', 'buddypress' ),
-							array(
-								'status' => rest_authorization_required_code(),
-							)
-						);
-					} else {
-						return true;
-					}
-
 				default :
 					return false;
 			}
@@ -313,7 +308,6 @@ class BP_REST_Group_Members_Endpoint extends WP_REST_Controller {
 		} else {
 			// Case 2: User is making a request about another user.
 			switch ( $request['action'] ) {
-				case 'remove' :
 				case 'ban' :
 				case 'unban' :
 				case 'promote' :
@@ -333,6 +327,130 @@ class BP_REST_Group_Members_Endpoint extends WP_REST_Controller {
 					return false;
 			}
 		}
+	}
+
+	/**
+	 * Delete a group membership.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$member  = new BP_Groups_Member( $request['user_id'], $request['group_id'] );
+		$removed = $member->remove();
+
+		if ( ! $removed ) {
+			return new WP_Error( 'bp_rest_group_member_failed_to_remove',
+				__( 'Could not remove member from this group.', 'buddypress' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		$retval = array(
+			$this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $member, $request )
+			),
+		);
+
+		$response = rest_ensure_response( $retval );
+
+		$user  = bp_rest_get_user( $request['user_id'] );
+		$group = $this->groups_endpoint->get_group_object( $request['group_id'] );
+
+		/**
+		 * Fires after a group member is deleted via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param WP_User          $user     The updated member.
+		 * @param BP_Groups_Member $member   The group member object.
+		 * @param BP_Groups_Group  $group    The group object.
+		 * @param WP_REST_Response $response The response data.
+		 * @param WP_REST_Request  $request  The request sent to the API.
+		 */
+		do_action( 'bp_rest_group_member_delete_item', $user, $member, $group, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to delete a group member.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function delete_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error( 'bp_rest_authorization_required',
+				__( 'Sorry, you need to be logged in to make an update.', 'buddypress' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		$user = bp_rest_get_user( $request['user_id'] );
+
+		if ( empty( $user->ID ) ) {
+			return new WP_Error( 'bp_rest_group_member_invalid_id',
+				__( 'Invalid group member id.', 'buddypress' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		$group = $this->groups_endpoint->get_group_object( $request['group_id'] );
+
+		if ( ! $group ) {
+			return new WP_Error( 'bp_rest_group_invalid_id',
+				__( 'Invalid group id.', 'buddypress' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		// Site administrators can do anything.
+		if ( bp_current_user_can( 'bp_moderate' ) ) {
+			return true;
+		}
+
+		$loggedin_user_id = bp_loggedin_user_id();
+
+		if ( $user->ID !== $loggedin_user_id ) {
+			if ( ! groups_is_user_admin( $loggedin_user_id, $group->id ) && ! groups_is_user_mod( $loggedin_user_id, $group->id ) ) {
+				return new WP_Error( 'bp_rest_group_member_cannot_remove',
+					__( 'Sorry, you are not allowed to remove this group member.', 'buddypress' ),
+					array(
+						'status' => rest_authorization_required_code(),
+					)
+				);
+			}
+		} else {
+			// Special case for self-removal: don't allow if it'd leave a group with no admins.
+			$user             = bp_rest_get_user( $request['user_id'] );
+			$group            = $this->groups_endpoint->get_group_object( $request['group_id'] );
+			$loggedin_user_id = bp_loggedin_user_id();
+
+			$group_admins = groups_get_group_admins( $group->id );
+			if ( 1 === count( $group_admins ) && $loggedin_user_id === $group_admins[0]->user_id && $user->ID === $loggedin_user_id ) {
+				return new WP_Error( 'bp_rest_group_member_cannot_remove',
+					__( 'Sorry, you are not allowed to leave this group.', 'buddypress' ),
+					array(
+						'status' => rest_authorization_required_code(),
+					)
+				);
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/groups/test-group-member-controller.php
+++ b/tests/groups/test-group-member-controller.php
@@ -13,7 +13,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 		$this->bp_factory   = new BP_UnitTest_Factory();
 		$this->endpoint     = new BP_REST_Group_Members_Endpoint();
 		$this->bp           = new BP_UnitTestCase();
-		$this->endpoint_url = '/buddypress/v1/group/members';
+		$this->endpoint_url = '/buddypress/v1/groups/';
 		$this->user         = $this->factory->user->create( array(
 			'role'       => 'administrator',
 			'user_email' => 'admin@example.com',
@@ -33,9 +33,17 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
+		$endpoint = $this->endpoint_url .  '(?P<group_id>[\d]+)/members';
+
 		// Main.
-		$this->assertArrayHasKey( $this->endpoint_url, $routes );
-		$this->assertCount( 2, $routes[ $this->endpoint_url ] );
+		$this->assertArrayHasKey( $endpoint, $routes );
+		$this->assertCount( 1, $routes[ $endpoint ] );
+
+		// Single.
+		$single_endpoint = $endpoint . '/(?P<user_id>[\d]+)';
+
+		$this->assertArrayHasKey( $single_endpoint, $routes );
+		$this->assertCount( 2, $routes[ $single_endpoint ] );
 	}
 
 	/**
@@ -54,10 +62,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u1 );
 
-		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
-		$request->set_query_params( array(
-			'group_id' => $g1,
-		) );
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . $g1 . '/members' );
 
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
@@ -101,9 +106,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u1 );
 
-		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . $g1 . '/members' );
 		$request->set_query_params( array(
-			'group_id' => $g1,
 			'page'     => 2,
 			'per_page' => 3,
 		) );
@@ -154,10 +158,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $this->group_id . '/members/' . $u  );
 		$request->set_query_params( array(
-			'group_id' => $this->group_id,
-			'user_id'  => $u,
 			'action'   => 'ban',
 		) );
 
@@ -185,10 +187,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $this->group_id . '/members/' . $u );
 		$request->set_query_params( array(
-			'group_id' => $this->group_id,
-			'user_id'  => $u,
 			'action'   => 'join',
 		) );
 
@@ -216,10 +216,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $this->group_id . '/members/' . $u );
 		$request->set_query_params( array(
-			'group_id' => $this->group_id,
-			'user_id'  => $u,
 			'action'   => 'join',
 		) );
 
@@ -251,10 +249,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $g1 . '/members/' . $u );
 		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u,
 			'action'   => 'join',
 		) );
 
@@ -276,10 +272,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $g1 . '/members/' . $u );
 		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u,
 			'action'   => 'join',
 		) );
 
@@ -298,10 +292,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u1 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $this->group_id . '/members/' . $u2 );
 		$request->set_query_params( array(
-			'group_id' => $this->group_id,
-			'user_id'  => $u2,
 			'action'   => 'join',
 		) );
 
@@ -312,7 +304,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group update_item
+	 * @group delete_item
 	 */
 	public function test_member_can_remove_himself_from_group() {
 		$u1 = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -327,12 +319,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u1 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
-		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u1,
-			'action'   => 'remove',
-		) );
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint_url . $g1 . '/members/' . $u1 );
 
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
@@ -349,7 +336,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group update_item
+	 * @group delete_item
 	 */
 	public function test_member_can_not_remove_others_from_group() {
 		$u1 = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -364,12 +351,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u1 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
-		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u2,
-			'action'   => 'remove',
-		) );
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint_url . $g1 . '/members/' . $u2 );
 
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
@@ -378,7 +360,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group update_item
+	 * @group delete_item
 	 */
 	public function test_admin_can_remove_member_from_group() {
 		$u1 = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -393,12 +375,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
-		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u1,
-			'action'   => 'remove',
-		) );
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint_url . $g1 . '/members/' . $u1 );
 
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
@@ -415,7 +392,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group update_item
+	 * @group delete_item
 	 */
 	public function test_group_admin_can_remove_member_from_group() {
 		$u1 = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -430,12 +407,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u3 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
-		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u1,
-			'action'   => 'remove',
-		) );
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint_url . $g1 . '/members/' . $u1 );
 
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
@@ -452,7 +424,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group update_item
+	 * @group delete_item
 	 */
 	public function test_group_admin_can_not_remove_himself_from_group() {
 		$u1 = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -466,12 +438,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u2 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
-		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u2,
-			'action'   => 'remove',
-		) );
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint_url . $g1 . '/members/' . $u2 );
 
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
@@ -489,10 +456,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $this->group_id . '/members/' . $u );
 		$request->set_query_params( array(
-			'group_id' => $this->group_id,
-			'user_id'  => $u,
 			'action'   => 'promote',
 			'role'     => 'mod',
 		) );
@@ -528,10 +493,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u2 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $g1 . '/members/' . $u1 );
 		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u1,
 			'action'   => 'promote',
 			'role'     => 'mod',
 		) );
@@ -568,10 +531,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u3 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $g1 . '/members/' . $u1 );
 		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u1,
 			'action'   => 'promote',
 			'role'     => 'mod',
 		) );
@@ -598,10 +559,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $g1 . '/members/' . $u2 );
 		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u2,
 			'action'   => 'demote',
 			'role'     => 'member',
 		) );
@@ -638,10 +597,8 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $u3 );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $g1 . '/members/' . $u2 );
 		$request->set_query_params( array(
-			'group_id' => $g1,
-			'user_id'  => $u2,
 			'action'   => 'demote',
 			'role'     => 'member',
 		) );
@@ -661,10 +618,10 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$group_id = REST_TESTS_IMPOSSIBLY_HIGH_NUMBER;
+
+		$request = new WP_REST_Request( 'PUT', $this->endpoint_url . $group_id . '/members/' . $u );
 		$request->set_query_params( array(
-			'group_id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
-			'user_id'  => $u,
 			'action'   => 'promote',
 			'role'     => 'mod',
 		) );
@@ -679,7 +636,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	 * @group update_item
 	 */
 	public function test_update_item_user_not_logged_in() {
-		$request  = new WP_REST_Request( 'PUT', $this->endpoint_url );
+		$request  = new WP_REST_Request( 'PUT', $this->endpoint_url . $this->group_id . '/members/0' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, 401 );
@@ -734,7 +691,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint_url );
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint_url . $this->group_id . '/members' );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
@@ -762,7 +719,7 @@ class BP_Test_REST_Group_Members_Endpoint extends WP_Test_REST_Controller_Testca
 
 	public function test_context_param() {
 		// Collection.
-		$request  = new WP_REST_Request( 'OPTIONS', $this->endpoint_url );
+		$request  = new WP_REST_Request( 'OPTIONS', $this->endpoint_url . $this->group_id . '/members' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
I began a review of #126 and, as in the case of the group membership endpoint, I found myself unhappy with the semantics of the URI format. `/group/invites/123`, where 123 is the user ID, doesn't make much sense to me.

So I thought I'd suggest a different format. Instead of applying it to the WIP invites endpoint, I've applied it to the already-merged members endpoint. Here's the new format:

`GET /groups/<group-id>/members`
`PUT (or POST) /groups/<group-id>/members/<user-id>`
`DELETE /groups/<group-id>/members/<user-id>`

This feels much more semantic, and I think we can apply a similar pattern elsewhere in the endpoints (such as for group invites). @renatonascalves Can you please give me your opinion on whether this is an improvement over what's currently there?