### PR TITLE
Fix Groups endpoint `get_items` method ordering

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1004,7 +1004,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'default'           => 'active',
 			'type'              => 'string',
 			'enum'              => array( 'active', 'newest', 'alphabetical', 'random', 'popular', 'most-forum-topics', 'most-forum-posts' ),
-			'sanitize_callback' => 'rest_validate_request_arg',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		$params['order'] = array(


### PR DESCRIPTION
Replace the `sanitize_callback` key by a `validate_callback` key for the `type` collection parameter. Otherwise the Groups ordering is broken as the `type` argument is always set to `true`.