### PR TITLE
Make sure xProfile component is active before using it

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -301,6 +301,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					);
 				}
 			}
+		} else {
+			$data = array( __( 'No extended profile data available as the component is inactive', 'buddypress' ) );
 		}
 
 		return $data;

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -279,25 +279,27 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	 * @return array XProfile info.
 	 */
 	protected function xprofile_data( $user_id ) {
-
-		// Get XProfile groups.
-		$groups = bp_xprofile_get_groups( array(
-			'user_id'          => $user_id,
-			'fetch_fields'     => true,
-			'fetch_field_data' => true,
-		) );
-
 		$data = array();
-		foreach ( $groups as $group ) {
-			$data['groups'][ $group->id ] = array(
-				'name' => $group->name,
-			);
 
-			foreach ( $group->fields as $item ) {
-				$data['groups'][ $group->id ]['fields'][ $item->id ] = array(
-					'name'  => $item->name,
-					'value' => maybe_unserialize( $item->data->value ),
+		// Get XProfile groups, only if the component is active.
+		if ( bp_is_active( 'xprofile' ) ) {
+			$groups = bp_xprofile_get_groups( array(
+				'user_id'          => $user_id,
+				'fetch_fields'     => true,
+				'fetch_field_data' => true,
+			) );
+
+			foreach ( $groups as $group ) {
+				$data['groups'][ $group->id ] = array(
+					'name' => $group->name,
 				);
+
+				foreach ( $group->fields as $item ) {
+					$data['groups'][ $group->id ]['fields'][ $item->id ] = array(
+						'name'  => $item->name,
+						'value' => maybe_unserialize( $item->data->value ),
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
The members endpoint, when using `bp_xprofile_get_groups()`, should check if the `xprofile` component is active first. Otherwise it will generate a fatal error if the xProfile component is not active.