### PR TITLE
Make sure bp_remove_has_published_posts_from_wp_api_user_query is doi…

### DIFF
--- a/includes/bp-members/bp-members-filters.php
+++ b/includes/bp-members/bp-members-filters.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 function bp_remove_has_published_posts_from_wp_api_user_query( $prepared_args, $request ) {
 	$namespace = bp_rest_namespace() . '/' . bp_rest_version() . '/members';
 
-	if ( 0 !== strpos( $request->get_route(), $namespace ) ) {
+	if ( 0 !== strpos( trim( $request->get_route(), '/' ), $namespace ) ) {
 		return $prepared_args;
 	}
 


### PR DESCRIPTION
…ng something :)

By removing leading and trailing slashes from the request route.

For instance my requests was `'/buddypress/v1/members'` and as a not logged in user I could only see the users who published a post.