### PR TITLE
Make sure the items proprerty is defined when the parameter type is an array

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1311,6 +1311,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -1319,6 +1320,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set includes specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -732,6 +732,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set includes specific group roles.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -740,6 +741,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific member IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1010,6 +1010,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Group statuses to limit results to.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -1035,6 +1036,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Get groups that are children of the specified group(s) IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -1044,6 +1046,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Get groups based on their meta data information.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
@@ -1051,6 +1054,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set includes groups with specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -1059,6 +1063,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -631,7 +631,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		$params['user_ids'] = array(
 			'description'       => __( 'Pass IDs of users to limit result set.', 'buddypress' ),
 			'default'           => array(),
-			'type'              => 'array()',
+			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -640,6 +641,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			'description'       => __( 'Ensure result set include specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -648,6 +650,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -656,6 +659,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			'description'       => __( 'Limit results set to certain type(s).', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -621,6 +621,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Limit fields by those restricted to a given member type, or array of member types. If `$user_id` is provided, the value of `$member_type` will be overridden by the member types of the provided user. The special value of \'any\' will return only those fields that are unrestricted by member type - i.e., those applicable to any type.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_member_types',
 			'validate_callback' => 'bp_rest_validate_member_types',
 		);
@@ -669,6 +670,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific profile field groups.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -677,6 +679,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific profile fields.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -671,6 +671,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Limit fields by those restricted to a given member type, or array of member types. If `$user_id` is provided, the value of `$member_type` will be overridden by the member types of the provided user. The special value of \'any\' will return only those fields that are unrestricted by member type - i.e., those applicable to any type.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_member_types',
 			'validate_callback' => 'bp_rest_validate_member_types',
 		);
@@ -711,6 +712,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific profile field groups.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -719,6 +721,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'description'       => __( 'Ensure result set excludes specific profile fields.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
+			'items'             => array( 'type' => 'string' ),
 			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);


### PR DESCRIPTION
The `rest_validate_request_arg()` function is checking for the type of the values an array contains. When omitting to set it for array types parameters it generates a notice error. A unit test about requesting group mods is also included as it is the way I found the notice error.

FYI @renatonascalves that's what I was talking about into the [8045 ticket on trac](https://buddypress.trac.wordpress.org/ticket/8045#comment:13).