### PR TITLE
Prevent a fatal error when the groups component is inactive

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1122,15 +1122,17 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		$user_id = get_current_user_id();
 		$retval  = false;
 
-		// If activity is from a group, do an extra cap check.
-		if ( ! $retval && ! empty( $item_id ) && bp_is_active( $component ) && buddypress()->groups->id === $component ) {
-			// Group admins and mods have access as well.
-			if ( groups_is_user_admin( $user_id, $item_id ) || groups_is_user_mod( $user_id, $item_id ) ) {
-				$retval = true;
+		if ( ! is_null( $component ) ) {
+			// If activity is from a group, do an extra cap check.
+			if ( ! $retval && ! empty( $item_id ) && bp_is_active( $component ) && buddypress()->groups->id === $component ) {
+				// Group admins and mods have access as well.
+				if ( groups_is_user_admin( $user_id, $item_id ) || groups_is_user_mod( $user_id, $item_id ) ) {
+					$retval = true;
 
-				// User is a member of the group.
-			} elseif ( (bool) groups_is_user_member( $user_id, $item_id ) ) {
-				$retval = true;
+					// User is a member of the group.
+				} elseif ( (bool) groups_is_user_member( $user_id, $item_id ) ) {
+					$retval = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
`bp_is_active( $component )` when `$component` is `NULL` is `true` as a result the groups functions used into the `show_hidden()` method of the Activity REST endpoint are unknown.
Using the `is_null()` check fixes this issue.