### PR TITLE
Check the group is active before using one of the component function

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1082,7 +1082,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		if ( 'groups' === $activity->component && ! empty( $activity->item_id ) ) {
+		if ( bp_is_active( 'groups' ) && 'groups' === $activity->component && ! empty( $activity->item_id ) ) {
 			$group = groups_get_group( $activity->item_id );
 
 			$links['group'] = array(


### PR DESCRIPTION
I just found a situation where a fatal error happened when BP_REST_Activity_Endpoint->prepare_links() is run: On a multisite config where BuddyPress is activated on two subsites. The first site has the groups component active the other one has not. As all activities no matter from what site they were posted are displayed in every site, I think it is safer to always check a component is active before using one of its function within the Activity Endpoint.