### PR TITLE
Use the `bp_rest_api_init` hook to register the REST controllers

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -43,86 +43,83 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 0.1.0
  */
-add_action(
-	'rest_api_init',
-	function() {
+function bp_rest() {
+	// Bail early if no core rest support.
+	if ( ! class_exists( 'WP_REST_Controller' ) ) {
+		return;
+	}
 
-		// Bail early if no core rest support.
-		if ( ! class_exists( 'WP_REST_Controller' ) ) {
-			return;
-		}
+	require_once dirname( __FILE__ ) . '/includes/bp-components/classes/class-bp-rest-components-endpoint.php';
+	$controller = new BP_REST_Components_Endpoint();
+	$controller->register_routes();
 
-		require_once dirname( __FILE__ ) . '/includes/bp-components/classes/class-bp-rest-components-endpoint.php';
-		$controller = new BP_REST_Components_Endpoint();
+	if ( bp_is_active( 'members' ) ) {
+		require_once dirname( __FILE__ ) . '/includes/bp-members/classes/class-bp-rest-members-endpoint.php';
+		$controller = new BP_REST_Members_Endpoint();
 		$controller->register_routes();
 
-		if ( bp_is_active( 'members' ) ) {
-			require_once dirname( __FILE__ ) . '/includes/bp-members/classes/class-bp-rest-members-endpoint.php';
-			$controller = new BP_REST_Members_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
-			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php';
-			$controller = new BP_REST_Attachments_Member_Avatar_Endpoint();
-			$controller->register_routes();
-		}
-
-		if ( bp_is_active( 'activity' ) ) {
-			require_once dirname( __FILE__ ) . '/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php';
-			$controller = new BP_REST_Activity_Endpoint();
-			$controller->register_routes();
-		}
-
-		if ( bp_is_active( 'xprofile' ) ) {
-			require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php';
-			$controller = new BP_REST_XProfile_Fields_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php';
-			$controller = new BP_REST_XProfile_Field_Groups_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php';
-			$controller = new BP_REST_XProfile_Data_Endpoint();
-			$controller->register_routes();
-		}
-
-		if ( bp_is_active( 'groups' ) ) {
-			require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php';
-			$controller = new BP_REST_Groups_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php';
-			$controller = new BP_REST_Group_Membership_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php';
-			$controller = new BP_REST_Group_Membership_Request_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php';
-			$controller = new BP_REST_Group_Invites_Endpoint();
-			$controller->register_routes();
-
-			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
-			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php';
-			$controller = new BP_REST_Attachments_Group_Avatar_Endpoint();
-			$controller->register_routes();
-		}
-
-		if ( bp_is_active( 'messages' ) ) {
-			require_once dirname( __FILE__ ) . '/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php';
-			$controller = new BP_REST_Messages_Endpoint();
-			$controller->register_routes();
-		}
-
-		if ( bp_is_active( 'notifications' ) ) {
-			require_once dirname( __FILE__ ) . '/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php';
-			$controller = new BP_REST_Notifications_Endpoint();
-			$controller->register_routes();
-		}
+		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
+		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php';
+		$controller = new BP_REST_Attachments_Member_Avatar_Endpoint();
+		$controller->register_routes();
 	}
-);
+
+	if ( bp_is_active( 'activity' ) ) {
+		require_once dirname( __FILE__ ) . '/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php';
+		$controller = new BP_REST_Activity_Endpoint();
+		$controller->register_routes();
+	}
+
+	if ( bp_is_active( 'xprofile' ) ) {
+		require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php';
+		$controller = new BP_REST_XProfile_Fields_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php';
+		$controller = new BP_REST_XProfile_Field_Groups_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php';
+		$controller = new BP_REST_XProfile_Data_Endpoint();
+		$controller->register_routes();
+	}
+
+	if ( bp_is_active( 'groups' ) ) {
+		require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php';
+		$controller = new BP_REST_Groups_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php';
+		$controller = new BP_REST_Group_Membership_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php';
+		$controller = new BP_REST_Group_Membership_Request_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php';
+		$controller = new BP_REST_Group_Invites_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
+		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php';
+		$controller = new BP_REST_Attachments_Group_Avatar_Endpoint();
+		$controller->register_routes();
+	}
+
+	if ( bp_is_active( 'messages' ) ) {
+		require_once dirname( __FILE__ ) . '/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php';
+		$controller = new BP_REST_Messages_Endpoint();
+		$controller->register_routes();
+	}
+
+	if ( bp_is_active( 'notifications' ) ) {
+		require_once dirname( __FILE__ ) . '/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php';
+		$controller = new BP_REST_Notifications_Endpoint();
+		$controller->register_routes();
+	}
+}
+add_action( 'bp_rest_api_init', 'bp_rest', 5 );
 
 /**
  * Load functions so that they can also be used out of a REST request.


### PR DESCRIPTION
This makes sure BP REST endpoints are loaded if BuddyPress is active. Using a function name to wrap the code is also very interesting as it allowes us to keep all options about the core merging/including strategy. For instance:
- we can avoid loading REST endpoints into BuddyPress if `has_action( "bp_rest_init_api_init", "bp_rest", 5 )`
- or we can disable the BP REST plugin endpoints from BuddyPress using `remove_action( "bp_rest_api_init", "bp_rest", 5 )`

Fixes #185

PS : I’ve tested it with https://buddypress.trac.wordpress.org/ticket/8045 + unitests 👌