### PR TITLE
Fix failing headers of the WP Rest Server

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 /**
  * BP REST: BP_REST_Group_Membership_Request_Endpoint class
  *


### PR DESCRIPTION
The extra tab at the beginning of `class-bp-rest-group-membership-request-endpoint.php` can break the headers of the WP Rest Server as there are then "already sent".