### PR TITLE
Prepare BuddyPress core inclusion

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -129,6 +129,11 @@ add_action( 'bp_rest_api_init', 'bp_rest', 5 );
 add_action(
 	'bp_include',
 	function() {
+		// BuddyPress is already including the needed functions.
+		if ( function_exists( 'bp_rest_namespace' ) ) {
+			return;
+		}
+
 		require_once dirname( __FILE__ ) . '/includes/functions.php';
 	}
 );


### PR DESCRIPTION
I think the only thing we need to do is to make sure to avoid a fatal error when BuddyPress will contain the functions of the`includes/functions.php` file.