### PR TITLE
Implement additional fields for Activity, Groups, Members & Notificat…

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -396,9 +396,16 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			)
 		);
 
+		$activity      = current( $activity['activities'] );
+		$fields_update = $this->update_additional_fields_for_object( $activity, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
 		$retval = array(
 			$this->prepare_response_for_collection(
-				$this->prepare_item_for_response( current( $activity['activities'] ), $request )
+				$this->prepare_item_for_response( $activity, $request )
 			),
 		);
 
@@ -496,7 +503,12 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$activity = $this->get_activity_object( $activity_id );
+		$activity      = $this->get_activity_object( $activity_id );
+		$fields_update = $this->update_additional_fields_for_object( $activity, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$retval = array(
 			$this->prepare_response_for_collection(
@@ -1179,7 +1191,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => esc_html__( 'Activity', 'buddypress' ),
+			'title'      => 'bp_activity',
 			'type'       => 'object',
 			'properties' => array(
 				'id'                => array(
@@ -1336,7 +1348,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param string $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_activity_schema', $schema );
+		return apply_filters( 'bp_rest_activity_schema', $this->add_additional_fields_schema( $schema ) );
 	}
 
 	/**

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php
@@ -393,7 +393,6 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -384,7 +384,6 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -292,7 +292,12 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$group = $this->get_group_object( $group_id );
+		$group         = $this->get_group_object( $group_id );
+		$fields_update = $this->update_additional_fields_for_object( $group, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$retval = array(
 			$this->prepare_response_for_collection(
@@ -369,7 +374,12 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$group = $this->get_group_object( $group_id );
+		$group         = $this->get_group_object( $group_id );
+		$fields_update = $this->update_additional_fields_for_object( $group, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$retval = array(
 			$this->prepare_response_for_collection(
@@ -844,7 +854,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => esc_html__( 'Group', 'buddypress' ),
+			'title'      => 'bp_groups',
 			'type'       => 'object',
 			'properties' => array(
 				'id'                 => array(
@@ -995,7 +1005,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_group_schema', $schema );
+		return apply_filters( 'bp_rest_group_schema', $this->add_additional_fields_schema( $schema ) );
 	}
 
 	/**

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -463,7 +463,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => esc_html__( 'Members', 'buddypress' ),
+			'title'      => 'bp_members',
 			'type'       => 'object',
 			'properties' => array(
 				'id'                 => array(
@@ -665,5 +665,28 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Updates the values of additional fields added to a data object.
+	 *
+	 * This function makes sure updating the field value thanks to the `id` property of
+	 * the created/updated object type is consistent accross BuddyPress components.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_User         $object  The WordPress user object.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error True on success, WP_Error object if a field cannot be updated.
+	 */
+	protected function update_additional_fields_for_object( $object, $request ) {
+		if ( isset( $object->data ) ) {
+			$member     = $object->data;
+			$member->id = $member->ID;
+		} else {
+			return new WP_Error( 'invalid_user', __( 'The data for the user was not found.', 'buddypress' ) );
+		}
+
+		return WP_REST_Controller::update_additional_fields_for_object( $member, $request );
 	}
 }

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -494,7 +494,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 		// @todo Set user avatar, user name, and user links for recipients.
 		// @todo What about starred threads, starred messages in a thread ?
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -290,7 +290,12 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$notification = $this->get_notification_object( $notification_id );
+		$notification  = $this->get_notification_object( $notification_id );
+		$fields_update = $this->update_additional_fields_for_object( $notification, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$retval = array(
 			$this->prepare_response_for_collection(
@@ -370,6 +375,12 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 					'status' => 500,
 				)
 			);
+		}
+
+		$fields_update = $this->update_additional_fields_for_object( $notification, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
 		}
 
 		$retval = array(
@@ -652,7 +663,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => esc_html__( 'Notifications', 'buddypress' ),
+			'title'      => 'bp_notifications',
 			'type'       => 'object',
 			'properties' => array(
 				'id'                => array(
@@ -706,7 +717,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_notifications_schema', $schema );
+		return apply_filters( 'bp_rest_notifications_schema', $this->add_additional_fields_schema( $schema ) );
 	}
 
 	/**

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -283,7 +283,6 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		);
 
 		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -541,7 +541,6 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -629,7 +629,6 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
 		return $data;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -249,3 +249,34 @@ function bp_rest_get_user( $user_id ) {
 
 	return $user;
 }
+
+/**
+ * Registers a new field on an existing BuddyPress object.
+ *
+ * @since 0.1.0
+ *
+ * @param string $component_id The name of the *active* component (eg: `activity`, `groups`, `xprofile`).
+ *                             Required.
+ * @param string $attribute    The attribute name. Required.
+ * @param array  $args {
+ *     Optional. An array of arguments used to handle the registered field.
+ *     @see `register_rest_field()` for a full description.
+ * }
+ * @return bool                True if the field has been registered successfully. False otherwise.
+ */
+function bp_rest_register_field( $component_id, $attribute, $args = array() ) {
+	if ( ! $component_id || ! bp_is_active( $component_id ) || ! $attribute ) {
+		return false;
+	}
+
+	$args = bp_parse_args( $args, array(
+		'get_callback'    => null,
+		'update_callback' => null,
+		'schema'          => null,
+	), 'rest_register_field' );
+
+	// Use the `bp_` prefix as we're using a WordPress global used for Post Types.
+	register_rest_field( 'bp_' . $component_id, $attribute, $args );
+
+	return isset( $GLOBALS['wp_rest_additional_fields'][ 'bp_' . $component_id ][ $attribute ] );
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -265,18 +265,27 @@ function bp_rest_get_user( $user_id ) {
  * @return bool                True if the field has been registered successfully. False otherwise.
  */
 function bp_rest_register_field( $component_id, $attribute, $args = array() ) {
+	$registered_fields = false;
+
 	if ( ! $component_id || ! bp_is_active( $component_id ) || ! $attribute ) {
-		return false;
+		return $registered_fields;
 	}
 
-	$args = bp_parse_args( $args, array(
-		'get_callback'    => null,
-		'update_callback' => null,
-		'schema'          => null,
-	), 'rest_register_field' );
+	$args = bp_parse_args(
+		$args, array(
+			'get_callback'    => null,
+			'update_callback' => null,
+			'schema'          => null,
+		),
+		'rest_register_field'
+	);
 
 	// Use the `bp_` prefix as we're using a WordPress global used for Post Types.
 	register_rest_field( 'bp_' . $component_id, $attribute, $args );
 
-	return isset( $GLOBALS['wp_rest_additional_fields'][ 'bp_' . $component_id ][ $attribute ] );
+	if ( isset( $GLOBALS['wp_rest_additional_fields'][ 'bp_' . $component_id ] ) ) {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'][ 'bp_' . $component_id ];
+	}
+
+	return isset( $registered_fields[ $attribute ] );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -272,7 +272,8 @@ function bp_rest_register_field( $component_id, $attribute, $args = array() ) {
 	}
 
 	$args = bp_parse_args(
-		$args, array(
+		$args,
+		array(
 			'get_callback'    => null,
 			'update_callback' => null,
 			'schema'          => null,

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -920,4 +920,88 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
+
+	public function update_additional_field( $value, $data, $attribute ) {
+		return bp_activity_update_meta( $data->id, '_' . $attribute, $value );
+	}
+
+	public function get_additional_field( $data, $attribute )  {
+		return bp_activity_get_meta( $data['id'], '_' . $attribute );
+	}
+
+	/**
+	 * @group additional_fields
+	 */
+	public function test_additional_fields() {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
+
+		bp_rest_register_field( 'activity', 'foo_field', array(
+			'get_callback'    => array( $this, 'get_additional_field' ),
+			'update_callback' => array( $this, 'update_additional_field' ),
+			'schema'          => array(
+				'description' => 'Activity Meta Field',
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		) );
+
+		$this->bp->set_current_user( $this->user );
+		$expected = 'bar_value';
+
+		// POST
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$params = $this->set_activity_data( array( 'foo_field' => $expected ) );
+		$request->set_body_params( $params );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$create_data = $response->get_data();
+		$this->assertTrue( $expected === $create_data[0]['foo_field'] );
+
+		// GET
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $create_data[0]['id'] ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$get_data = $response->get_data();
+		$this->assertTrue( $expected === $get_data[0]['foo_field'] );
+
+		$GLOBALS['wp_rest_additional_fields'] = $registered_fields;
+	}
+
+	/**
+	 * @group additional_fields
+	 */
+	public function test_update_additional_fields() {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
+
+		bp_rest_register_field( 'activity', 'bar_field', array(
+			'get_callback'    => array( $this, 'get_additional_field' ),
+			'update_callback' => array( $this, 'update_additional_field' ),
+			'schema'          => array(
+				'description' => 'Activity Meta Field',
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		) );
+
+		$this->bp->set_current_user( $this->user );
+		$expected = 'foo_value';
+		$a_id     = $this->bp_factory->activity->create();
+
+		// PUT
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $a_id ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_activity_data( array( 'bar_field' => 'foo_value' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$update_data = $response->get_data();
+		$this->assertTrue( $expected === $update_data[0]['bar_field'] );
+
+		$GLOBALS['wp_rest_additional_fields'] = $registered_fields;
+	}
 }

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -677,4 +677,88 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
+
+	public function update_additional_field( $value, $data, $attribute ) {
+		return groups_update_groupmeta( $data->id, '_' . $attribute, $value );
+	}
+
+	public function get_additional_field( $data, $attribute )  {
+		return groups_get_groupmeta( $data['id'], '_' . $attribute );
+	}
+
+	/**
+	 * @group additional_fields
+	 */
+	public function test_additional_fields() {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
+
+		bp_rest_register_field( 'groups', 'foo_field', array(
+			'get_callback'    => array( $this, 'get_additional_field' ),
+			'update_callback' => array( $this, 'update_additional_field' ),
+			'schema'          => array(
+				'description' => 'Groups single item Meta Field',
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		) );
+
+		$this->bp->set_current_user( $this->user );
+		$expected = 'bar_value';
+
+		// POST
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$params = $this->set_group_data( array( 'foo_field' => $expected ) );
+		$request->set_body_params( $params );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$create_data = $response->get_data();
+		$this->assertTrue( $expected === $create_data[0]['foo_field'] );
+
+		// GET
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $create_data[0]['id'] ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$get_data = $response->get_data();
+		$this->assertTrue( $expected === $get_data[0]['foo_field'] );
+
+		$GLOBALS['wp_rest_additional_fields'] = $registered_fields;
+	}
+
+	/**
+	 * @group additional_fields
+	 */
+	public function test_update_additional_fields() {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
+
+		bp_rest_register_field( 'groups', 'bar_field', array(
+			'get_callback'    => array( $this, 'get_additional_field' ),
+			'update_callback' => array( $this, 'update_additional_field' ),
+			'schema'          => array(
+				'description' => 'Groups single item Meta Field',
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		) );
+
+		$this->bp->set_current_user( $this->user );
+		$expected = 'foo_value';
+		$g_id     = $this->bp_factory->group->create();
+
+		// PUT
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $g_id ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_group_data( array( 'bar_field' => 'foo_value' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$update_data = $response->get_data();
+		$this->assertTrue( $expected === $update_data[0]['bar_field'] );
+
+		$GLOBALS['wp_rest_additional_fields'] = $registered_fields;
+	}
 }

--- a/tests/notifications/test-controller.php
+++ b/tests/notifications/test-controller.php
@@ -462,4 +462,89 @@ class BP_Test_REST_Notifications_Endpoint extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
+
+	public function update_additional_field( $value, $data, $attribute ) {
+		return bp_notifications_update_meta( $data->id, '_' . $attribute, $value );
+	}
+
+	public function get_additional_field( $data, $attribute )  {
+		return bp_notifications_get_meta( $data['id'], '_' . $attribute );
+	}
+
+	/**
+	 * @group additional_fields
+	 */
+	public function test_additional_fields() {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
+
+		bp_rest_register_field( 'notifications', 'foo_field', array(
+			'get_callback'    => array( $this, 'get_additional_field' ),
+			'update_callback' => array( $this, 'update_additional_field' ),
+			'schema'          => array(
+				'description' => 'Notification Meta Field',
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		) );
+
+		$this->bp->set_current_user( $this->user );
+		$expected = 'bar_value';
+
+		// POST
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+
+		$params = $this->set_notification_data( array( 'foo_field' => $expected ) );
+		$request->set_body_params( $params );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$create_data = $response->get_data();
+		$this->assertTrue( $expected === $create_data[0]['foo_field'] );
+
+		// GET
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $create_data[0]['id'] ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$get_data = $response->get_data();
+		$this->assertTrue( $expected === $get_data[0]['foo_field'] );
+
+		$GLOBALS['wp_rest_additional_fields'] = $registered_fields;
+	}
+
+	/**
+	 * @group additional_fields
+	 */
+	public function test_update_additional_fields() {
+		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
+
+		bp_rest_register_field( 'notifications', 'bar_field', array(
+			'get_callback'    => array( $this, 'get_additional_field' ),
+			'update_callback' => array( $this, 'update_additional_field' ),
+			'schema'          => array(
+				'description' => 'Notification Meta Field',
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		) );
+
+		$notification_id = $this->bp_factory->notification->create( $this->set_notification_data() );
+		$this->bp->set_current_user( $this->user );
+		$expected = 'foo_value';
+
+		// Put
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $notification_id ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_notification_data( array( 'is_new' => 0, 'bar_field' => 'foo_value' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$update_data = $response->get_data();
+		$this->assertTrue( $expected === $update_data[0]['bar_field'] );
+
+		$GLOBALS['wp_rest_additional_fields'] = $registered_fields;
+	}
 }


### PR DESCRIPTION
…ions

Althought the `WP_REST_Controller::add_additional_fields_to_object` were used into these components, there was no way to actually get these fields or set them.
This PR do the necessary stuff:
- make sure the title property of the schema is `bp` prefixed and uses the component ID as this property is used to get the registered additional fields for the endpoint.
- wrap `register_rest_field` into a specific BP REST function making sure to prefix all registered field with `bp` as this global is used for custom post types
- make sure the endpoint schema can be appended with the custom fields schema
- make sure creating/updating an item triggers the `WP_REST_Controller::update_additional_fields_for_object` method

I also removed `WP_REST_Controller::add_additional_fields_to_object`:
1. from avatar endpoints (I am wondering what avatar meta could be used?),
2. from the Message endpoint as it is actually a Thread endpoint and because there is something wrong with cache,
3. from xprofiles because it needs more work as meta for xprofile can be typed for data, group or field. On this last point I suggest to discuss about the best scenario (adding a last parameter to `bp_rest_register_field` and calling the object type and schema title `bp_xpofile_$type` seems to be a good way to do it)

PS: About 2. & 3. I'll open GH issues soon.