### PR TITLE
Improve arguments description for the Activity endpoint methods

### DIFF
--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -608,8 +608,12 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_update_item_invalid_id() {
 		$this->bp->set_current_user( $this->user );
+		$a = $this->bp_factory->activity->create();
 
 		$request  = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'type' => 'activity_update' ) ) );
+		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_invalid_id', $response, 404 );
@@ -624,6 +628,9 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( $this->activity_id, $activity->id );
 
 		$request  = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $activity->id ) );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'type' => $activity->type ) ) );
+		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, 401 );
@@ -696,7 +703,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_update_activity_empty_type', $response, 500 );
+		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
 	}
 
 	/**


### PR DESCRIPTION
1. Make sure the `id` is listed as an argument for the `buddypress/v1/activity/<id>` and `buddypress/v1/activity/<id>/favorite` routes
2. Set the type of the content argument to `string` for CREATABLE and EDITABLE transport methods.
3. Set the type argument as required for the EDITABLE method (adapt the unit tests accordingly).
4. Improve strings used to describe the argument replacing "objetc" by "activity".
5. Set the status, comments, comment_count arguments as read only to remove them from EDITABLE and CREATABLE transport methods.
6. Set the title as readonly: activity actions are generated dynamically and remove the readonly property from the link argument: link is editable.

Note about the status: we will probably need specific routes to an spam/ham activity in a future release.

The [documentation for the activity endpoint](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/activity/) has been written taking in account the above 6 points.