### PR TITLE
Improve Profile field arguments and some xProfile field features

### DIFF
--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -775,7 +775,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 		);
 
 		$params['hide_empty_groups'] = array(
-			'description'       => __( 'True to hide groups that do not have any fields.', 'buddypress' ),
+			'description'       => __( 'Whether to hide profile groups of fields that do not have any profile fields or not.', 'buddypress' ),
 			'default'           => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
@@ -799,16 +799,8 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'validate_callback' => 'bp_rest_validate_member_types',
 		);
 
-		$params['hide_empty_groups'] = array(
-			'description'       => __( 'True to hide field groups where the user has not provided data.', 'buddypress' ),
-			'default'           => false,
-			'type'              => 'boolean',
-			'sanitize_callback' => 'rest_sanitize_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
 		$params['hide_empty_fields'] = array(
-			'description'       => __( 'True to hide fields where the user has not provided data.', 'buddypress' ),
+			'description'       => __( 'Whether to hide profile groups of fields that do not have any profile fields or not.', 'buddypress' ),
 			'default'           => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',

--- a/tests/xprofile/test-field-controller.php
+++ b/tests/xprofile/test-field-controller.php
@@ -252,7 +252,7 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $this->field_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 
-		$params = $this->set_field_data( [ 'name' => $new_name, 'field_group_id' => $this->group_id ] );
+		$params = $this->set_field_data( [ 'name' => $new_name, 'group_id' => $this->group_id ] );
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
@@ -276,7 +276,7 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 
 		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$request->add_header( 'content-type', 'application/json' );
-		$params  = $this->set_field_data( [ 'field_group_id' => $this->group_id ] );
+		$params  = $this->set_field_data( [ 'group_id' => $this->group_id ] );
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
@@ -290,7 +290,7 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $this->field_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 
-		$params = $this->set_field_data( [ 'field_group_id' => $this->group_id ] );
+		$params = $this->set_field_data( [ 'group_id' => $this->group_id ] );
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
@@ -306,7 +306,7 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 
 		$request  = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $this->field_id ) );
 		$request->add_header( 'content-type', 'application/json' );
-		$params  = $this->set_field_data( [ 'field_group_id' => $this->group_id ] );
+		$params  = $this->set_field_data( [ 'group_id' => $this->group_id ] );
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
@@ -403,9 +403,9 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 
 	protected function set_field_data( $args = array() ) {
 		return wp_parse_args( $args, array(
-			'type'           => 'checkbox',
-			'name'           => 'Test Field Name',
-			'field_group_id' => $this->group_id,
+			'type'     => 'checkbox',
+			'name'     => 'Test Field Name',
+			'group_id' => $this->group_id,
 		) );
 	}
 
@@ -539,9 +539,9 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $this->field_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$params = $this->set_field_data( array(
-			'name'           => $this->endpoint->get_xprofile_field_object( $this->field_id )->name,
-			'field_group_id' => $this->group_id,
-			'bar_field_key'  => $expected,
+			'name'          => $this->endpoint->get_xprofile_field_object( $this->field_id )->name,
+			'group_id'      => $this->group_id,
+			'bar_field_key' => $expected,
 		) );
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
1. Remove the duplicate `hide_empty_groups` parameter from the Group and Profile field endpoints.
2. Remove the `create_update_item_params()` method in favor of `get_endpoint_args_for_item_schema()` for consistency with other endpoints.
3. Make sure the ID is listed in arguments for the `/buddypress/v1/xprofile/fields/<id>` routes.
4. Set the default property of the `user_id` to `0` to avoid requesting for profile data by default for the GET transport method of `/buddypress/v1/xprofile/fields/<id>` route.
5. Introduce `get_endpoint_args_for_item_schema()` to build the schema for the EDITABLE and CREATABLE transport methods.
5.1 Make sure the visibility and autoling property of fields can be set using the endpoint.
5.2 Make sure `group_id`, `type`, and `name` are described as Required for the CREATABLE method.
5.3 Add a filter to eventually remove the specific arguments for visibility and autolink fields property.
6. Introduce a new method to set the visibility and autolink properties for the `create_item()` and `update_item()` methods.
7. Use `group_id` instead of `field_group_id` in REST requests (Update the unit tests accordingly).
8. Make sure it is possible to update fields property independently using the current value of the profile field object as fallback. This avoids resetting all properties when we only edit the description for example.
9. Make sure it is not possible to edit the `can_delete` property of the field ID: `bp_xprofile_fullname_field_id()`
10. Improve the descriptions of the item schema and make sure `readonly` and `default` property are set the right way.

NB: the [documentation for the Profile field endpoint](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/extended-profiles/profile-field/) has been written taking in account the above 10 points.