### PR TITLE
Improve Profile data arguments and the way are retrieved field values

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -495,7 +495,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 
 		// Get XProfile groups, only if the component is active.
 		if ( bp_is_active( 'xprofile' ) ) {
-			$field_enpoint = new BP_REST_XProfile_Fields_Endpoint();
+			$fields_endpoint = new BP_REST_XProfile_Fields_Endpoint();
 
 			$groups = bp_xprofile_get_groups(
 				array(
@@ -515,8 +515,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						'name'  => $item->name,
 						'value' => array(
 							'raw'          => $item->data->value,
-							'unserialized' => $field_enpoint->get_profile_field_unserialized_value( $item->data->value ),
-							'rendered'     => $field_enpoint->get_profile_field_rendered_value( $item->data->value, $item ),
+							'unserialized' => $fields_endpoint->get_profile_field_unserialized_value( $item->data->value ),
+							'rendered'     => $fields_endpoint->get_profile_field_rendered_value( $item->data->value, $item ),
 						),
 					);
 				}

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -495,6 +495,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 
 		// Get XProfile groups, only if the component is active.
 		if ( bp_is_active( 'xprofile' ) ) {
+			$field_enpoint = new BP_REST_XProfile_Fields_Endpoint();
+
 			$groups = bp_xprofile_get_groups(
 				array(
 					'user_id'          => $user_id,
@@ -511,7 +513,11 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				foreach ( $group->fields as $item ) {
 					$data['groups'][ $group->id ]['fields'][ $item->id ] = array(
 						'name'  => $item->name,
-						'value' => maybe_unserialize( $item->data->value ),
+						'value' => array(
+							'raw'          => $item->data->value,
+							'unserialized' => $field_enpoint->get_profile_field_unserialized_value( $item->data->value ),
+							'rendered'     => $field_enpoint->get_profile_field_rendered_value( $item->data->value, $item ),
+						),
 					);
 				}
 			}

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -139,7 +139,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		$field = $this->get_xprofile_field_object( $request['field_id'] );
 
 		if ( empty( $field->id ) ) {
-			return new WP_Error(
+			$retval = new WP_Error(
 				'bp_rest_invalid_id',
 				__( 'Invalid field id.', 'buddypress' ),
 				array(
@@ -151,8 +151,8 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		// Check the user can view this field value.
 		$hidden_user_fields = bp_xprofile_get_hidden_fields_for_user( $request['user_id'] );
 
-		if ( in_array( $field->id, $hidden_user_fields, true ) ) {
-			return new WP_Error(
+		if ( true === $retval && in_array( $field->id, $hidden_user_fields, true ) ) {
+			$retval = new WP_Error(
 				'bp_rest_hidden_profile_field',
 				__( 'Sorry, the profile field value is not viewable for this user.', 'buddypress' ),
 				array(

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -148,6 +148,17 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// Check the requested user exists.
+		if ( true === $retval && ! bp_rest_get_user( $request['user_id'] ) ) {
+			$retval = new WP_Error(
+				'bp_rest_member_invalid_id',
+				__( 'Invalid member id.', 'buddypress' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
 		// Check the user can view this field value.
 		$hidden_user_fields = bp_xprofile_get_hidden_fields_for_user( $request['user_id'] );
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -533,8 +533,8 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 					'description' => __( 'The value of the field data.', 'buddypress' ),
 					'type'        => 'object',
 					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						'sanitize_callback' => null,
+						'validate_callback' => null,
 					),
 					'properties'  => array(
 						'raw'          => array(

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -289,9 +289,12 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			// Ensure that the requester is allowed to see this field.
 			$hidden_user_fields = bp_xprofile_get_hidden_fields_for_user( $request['user_id'] );
 
-			$field->data->value = in_array( $profile_field_id, $hidden_user_fields, true )
-				? __( 'Value suppressed.', 'buddypress' )
-				: xprofile_get_field_data( $profile_field_id, $request['user_id'] );
+			if ( in_array( $profile_field_id, $hidden_user_fields, true ) ) {
+				$field->data->value = __( 'Value suppressed.', 'buddypress' );
+			} else {
+				// Get the raw value for the field.
+				$field->data->value = BP_XProfile_ProfileData::get_value_byid( $profile_field_id, $request['user_id'] );
+			}
 
 			// Set 'fetch_field_data' to true so that the data is included in the response.
 			$request['fetch_field_data'] = true;
@@ -782,7 +785,12 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			if ( isset( $field->data->id ) ) {
 				$data['data']['id'] = $field->data->id;
 			}
-			$data['data']['value'] = maybe_unserialize( $field->data->value );
+
+			$data['data']['value'] = array(
+				'raw'          => $field->data->value,
+				'unserialized' => $this->get_profile_field_unserialized_value( $field->data->value ),
+				'rendered'     => $this->get_profile_field_rendered_value( $field->data->value, $field ),
+			);
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -841,6 +849,73 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 		}
 
 		return $field;
+	}
+
+	/**
+	 * Retrieve the rendered value of a profile field.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param  string                    $value         The raw value of the field.
+	 * @param  integer|BP_XProfile_Field $profile_field The ID or the full object for the field.
+	 * @return string                                   The field value for the display context.
+	 */
+	public function get_profile_field_rendered_value( $value = '', $profile_field = null ) {
+		if ( ! $value ) {
+			return '';
+		}
+
+		$profile_field = xprofile_get_field( $profile_field );
+
+		if ( ! isset( $profile_field->id ) ) {
+			return '';
+		}
+
+		// Unserialize the BuddyPress way.
+		$value = bp_unserialize_profile_field( $value );
+
+		global $field;
+		$reset_global = $field;
+
+		// Set the $field global as the `xprofile_filter_link_profile_data` filter needs it.
+		$field = $profile_field;
+
+		/**
+		 * Apply Filters to sanitize XProfile field value.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param string $value Value for the profile field.
+		 * @param string $type  Type for the profile field.
+		 * @param int    $id    ID for the profile field.
+		 */
+		$value = apply_filters( 'bp_get_the_profile_field_value', $value, $field->type, $field->id );
+
+		// Reset the global before returning the value.
+		$field = $reset_global;
+
+		return $value;
+	}
+
+	/**
+	 * Retrieve the unserialized value of a profile field.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param  string $value The raw value of the field.
+	 * @return array         The unserialized field value.
+	 */
+	public function get_profile_field_unserialized_value( $value = '' ) {
+		if ( ! $value ) {
+			return '';
+		}
+
+		$unserialized_value = maybe_unserialize( $value );
+		if ( ! is_array( $unserialized_value ) ) {
+			$unserialized_value = (array) $unserialized_value;
+		}
+
+		return $unserialized_value;
 	}
 
 	/**
@@ -954,8 +1029,27 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 				'data'              => array(
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'The saved value for this profile field.', 'buddypress' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'readonly'    => true,
+					'properties'  => array(
+						'raw'          => array(
+							'description' => __( 'Value for the field, as it exists in the database.', 'buddypress' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'unserialized' => array(
+							'description' => __( 'Unserialized value for the field, regular string will be casted as array.', 'buddypress' ),
+							'type'        => 'array',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'rendered'     => array(
+							'description' => __( 'HTML value for the field, transformed for display.' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
 				),
 			),
 		);

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -907,7 +907,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 	 */
 	public function get_profile_field_unserialized_value( $value = '' ) {
 		if ( ! $value ) {
-			return '';
+			return array();
 		}
 
 		$unserialized_value = maybe_unserialize( $value );

--- a/tests/xprofile/test-data-controller.php
+++ b/tests/xprofile/test-data-controller.php
@@ -35,7 +35,7 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$endpoint = $this->endpoint_url . '(?P<field_id>[\d]+)/data/(?P<user_id>[\d]+)';
 
 		$this->assertArrayHasKey( $endpoint, $routes );
-		$this->assertCount( 2, $routes[ $endpoint ] );
+		$this->assertCount( 3, $routes[ $endpoint ] );
 	}
 
 	/**
@@ -49,29 +49,56 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	 * @group get_item
 	 */
 	public function test_get_item() {
-		return true;
+		$this->bp->set_current_user( $this->user );
+		xprofile_set_field_data( $this->field_id, $this->user, 'foo' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, $this->user ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$all_data = $response->get_data();
+		$this->assertNotEmpty( $all_data );
+
+		$this->assertEquals( $all_data[0]['value']['unserialized'], array( 'foo' ) );
 	}
 
 	/**
-	 * @group create_item
+	 * @group get_item
 	 */
-	public function test_create_item() {
+	public function test_get_item_hidden_for_user() {
+		$f = $this->bp_factory->xprofile_field->create( array( 'field_group_id' => $this->group_id ) );
+		xprofile_set_field_data( $f, $this->user, 'bar' );
+		xprofile_set_field_visibility_level( $f, $this->user, 'adminsonly' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/data/%d', $f, $this->user ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_item() {
 		$this->bp->set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, $this->user ) );
-		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->add_header( 'content-type', 'application/json' );
 
 		$params = $this->set_field_data();
-		$request->set_body_params( $params );
+		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->check_create_field_response( $response );
 	}
 
 	/**
-	 * @group create_item
+	 * @group update_item
 	 */
-	public function test_create_item_user_not_logged_in() {
+	public function test_update_item_user_not_logged_in() {
 		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, $this->user ) );
 		$request->add_header( 'content-type', 'application/json' );
 
@@ -83,9 +110,9 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group create_item
+	 * @group update_item
 	 */
-	public function test_create_item_user_without_permission() {
+	public function test_update_item_user_without_permission() {
 		$u = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$this->bp->set_current_user( $u );
 
@@ -100,9 +127,9 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group create_item
+	 * @group update_item
 	 */
-	public function test_create_item_invalid_field_id() {
+	public function test_update_item_invalid_field_id() {
 		$this->bp->set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER, $this->user ) );
@@ -116,9 +143,9 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group create_item
+	 * @group update_item
 	 */
-	public function test_create_item_invalid_member_id() {
+	public function test_update_item_invalid_member_id() {
 		$this->bp->set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
@@ -132,9 +159,9 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @group update_item
+	 * @group create_item
 	 */
-	public function test_update_item() {
+	public function test_create_item() {
 		return true;
 	}
 
@@ -160,7 +187,7 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 		$this->assertNotEmpty( $data );
 
-		$this->assertEmpty( $data[0]['value'] );
+		$this->assertEmpty( $data[0]['value']['unserialized'] );
 
 		$field_data = $this->endpoint->get_xprofile_field_data_object( $data[0]['field_id'], $data[0]['user_id'] );
 
@@ -193,7 +220,7 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 		$this->assertNotEmpty( $data );
 
-		$this->assertEmpty( $data[0]['value'] );
+		$this->assertEmpty( $data[0]['value']['unserialized'] );
 
 		$field_data = $this->endpoint->get_xprofile_field_data_object( $data[0]['field_id'], $data[0]['user_id'] );
 
@@ -277,7 +304,7 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	protected function check_field_data( $field_data, $data ) {
 		$this->assertEquals( $field_data->field_id, $data['field_id'] );
 		$this->assertEquals( $field_data->user_id, $data['user_id'] );
-		$this->assertEquals( $field_data->value, $data['value'] );
+		$this->assertEquals( (array) $field_data->value, $data['value']['unserialized'] );
 		$this->assertEquals( bp_rest_prepare_date_response( $field_data->last_updated ), $data['last_updated'] );
 	}
 
@@ -287,7 +314,7 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 4, count( $properties ) );
+		$this->assertEquals( 5, count( $properties ) );
 		$this->assertArrayHasKey( 'field_id', $properties );
 		$this->assertArrayHasKey( 'user_id', $properties );
 		$this->assertArrayHasKey( 'value', $properties );
@@ -327,13 +354,14 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 
 		// POST
 		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, $this->user ) );
-		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->add_header( 'content-type', 'application/json' );
+		
 
 		$params = $this->set_field_data( array(
 			'foo_metadata_key' => $expected,
 		) );
 
-		$request->set_body_params( $params );
+		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
 		$create_data = $response->get_data();


### PR DESCRIPTION
To preserve some consistency about data types and to make sure values are fully usable I have first edited the way field values are populating the REST responses (possibly into the Member, Profile Group, Profile Field and Profile Data endpoints):
- the `value` property is now an object exposing 3 versions of the value:
  - `raw` is the db version of the value (edit context only),
  - `unserialized` is always an array containing one or more field values (for instance checkboxes or multi-selectbox),
  - `rendered` is the HTML string output on the front-end. It may contain a link if the field has an `autolink` status set to `on`.
- an array is expected when saving a profile data. This is to take in account checkboxes or multi-selectbox which accept multiple values. If a string is used, it is transformed into an array before doing the inverse operation if the field type `! supports_multiple_defaults`.

To make this possible I had to introduce `BP_REST_XProfile_Fields_Endpoint->get_profile_field_unserialized_value()` and `BP_REST_XProfile_Fields_Endpoint->get_profile_field_rendered_value()` methods.

I have edited the corresponding item schemas and unit tests.

Back to Profile Data:
- I think it is important to have a `get_item()` method, otherwise it seems very weird not to be able to get Profile Data into the corresponding endpoint.
- I have switched from the `create_item()` method to the `update_item()` method (we have more verbs this way!) and most importantly it seems more consistent as the value is created as null during the Profile Field creation in a way.

Just like for the other endpoints, I have improved the arguments description and written the [endpoint documentation](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/extended-profiles/profile-data/) accordingly to the above points.