### PR TITLE
Improve Groups endpoint arguments and fix potential issues

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -962,9 +962,9 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				'status'             => array(
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'The status of the Group.', 'buddypress' ),
-					'required'    => true,
 					'type'        => 'string',
 					'enum'        => buddypress()->groups->valid_status,
+					'default'     => 'public',
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_key',
 					),

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -695,11 +695,11 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		if ( ! empty( $schema['properties']['creator_id'] ) && isset( $request['creator_id'] ) ) {
 			$prepared_group->creator_id = (int) $request['creator_id'];
 
-		// Fallback on the existing creator id in case of an update.
+			// Fallback on the existing creator id in case of an update.
 		} elseif ( isset( $group->creator_id ) && $group->creator_id ) {
 			$prepared_group->creator_id = (int) $group->creator_id;
 
-		// Fallback on the current user otherwise.
+			// Fallback on the current user otherwise.
 		} else {
 			$prepared_group->creator_id = bp_loggedin_user_id();
 		}

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -608,6 +608,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 			'slug'        => 'group-name',
 			'description' => 'Group Description',
 			'creator_id'  => $this->user,
+			'status'      => 'public',
 		) );
 	}
 

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -340,6 +340,21 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * @group create_item
+	 */
+	public function test_create_item_invalid_status() {
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_group_data( array( 'status' => 'foo' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	/**
 	 * @group update_item
 	 */
 	public function test_update_item() {
@@ -450,6 +465,24 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$group = $this->endpoint->get_group_object( $new_data['id'] );
 		$this->assertEquals( $params['description'], $group->description );
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_item_invalid_status() {
+		$group = $this->endpoint->get_group_object( $this->group_id );
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $group->id ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_group_data( array( 'status' => 'bar' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	/**
@@ -608,7 +641,6 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 			'slug'        => 'group-name',
 			'description' => 'Group Description',
 			'creator_id'  => $this->user,
-			'status'      => 'public',
 		) );
 	}
 


### PR DESCRIPTION
1. Make sure the ID argument is listed into the `buddypress/v1/groups/<group_id>` routes.
2. Edit some arguments specifically for the EDITABLE and CREATABLE methods:
  - Set the group description type to `string` for both methods
  - Remove the slug argument from the available arguments for the EDITABLE one.
3. The `user_id` was not an argument, I have changed it for the existing `creator_id`
4. In the `prepare_item_for_database()` method: If the `creator_id` is not set, we need to fallback on the existing `creator_id` if set (Group update) otherwise the current user (Group create).
5. The `slug` needs more checks: if it is a group creation we fall back on the group `name` if the `slug` hasn't been sent into the request. If it is an update and the `slug` is not the same than the existing one we use the new one. We also make sure slugs are sanitized and unique in both cases.
6. Improve the description of the item schema: some types and some Required/Readonly/Default properties which were not right and wasn't listed into the UPDATE/CREATE arguments.
7. Add 2 more unit tests to check the `status` is valid for `create_item` and `update_item`

I've written the [Groups endpoint documentation](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/user-groups/groups/) according to these 7 points.