### PR TITLE
Use the view context to let regular users join a public group

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -370,17 +370,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $user, $request ) {
-		$user    = get_userdata( $user->ID );
-		$data    = $this->user_data( $user->data );
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-
-		if ( 'edit' === $context ) {
-			$data['registered_date']    = bp_rest_prepare_date_response( $user->data->user_registered );
-			$data['roles']              = (array) array_values( $user->roles );
-			$data['capabilities']       = (array) array_keys( $user->allcaps );
-			$data['extra_capabilities'] = (array) array_keys( $user->caps );
-		}
-
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->user_data( $user, $context );
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
@@ -406,10 +397,11 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param WP_User $user User object.
+	 * @param WP_User $user    User object.
+	 * @param string  $context The context of the request. Defaults to 'view'.
 	 * @return array
 	 */
-	public function user_data( $user ) {
+	public function user_data( $user, $context = 'view' ) {
 		$data = array(
 			'id'                 => $user->ID,
 			'name'               => $user->display_name,
@@ -422,6 +414,13 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			'registered_date'    => '',
 			'xprofile'           => $this->xprofile_data( $user->ID ),
 		);
+
+		if ( 'edit' === $context ) {
+			$data['registered_date']    = bp_rest_prepare_date_response( $user->data->user_registered );
+			$data['roles']              = (array) array_values( $user->roles );
+			$data['capabilities']       = (array) array_keys( $user->allcaps );
+			$data['extra_capabilities'] = (array) array_keys( $user->caps );
+		}
 
 		// The name used for that user in @-mentions.
 		if ( bp_is_active( 'activity' ) ) {


### PR DESCRIPTION
1. Use `groups_join_group()` into the `view` context of `BP_REST_Group_Membership_Endpoint->create_item()`. The existing code to add a user to a group has been restricted to site administrators.
2. Adapt unit tests and add one to test the `edit` context for Administrators.
3. Make sure the user trying to join a public group is not already a member and has not been banned from the group.
4. Improve `BP_REST_Members_Endpoint->user_data()` to accept a context argument so that using the edit context will retrieve caps, roles etc..
5. Add an [Info block to the documentation](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/user-groups/group-membership/#add-a-specific-member-into-a-group) of the route to inform how to make a logged in user join a public group.

NB: this PR is applying the decision we took during the August 7th dev chat.