### PR TITLE
Harmonize delete_item() method responses

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -607,11 +607,11 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
-		$activity = $this->get_activity_object( $request );
-
 		$request->set_param( 'context', 'edit' );
 
-		$response = $this->prepare_item_for_response( $activity, $request );
+		// Get the activity before it's deleted.
+		$activity = $this->get_activity_object( $request );
+		$previous = $this->prepare_item_for_response( $activity, $request );
 
 		if ( 'activity_comment' === $activity->type ) {
 			$retval = bp_activity_delete_comment( $activity->item_id, $activity->id );
@@ -632,6 +632,15 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				)
 			);
 		}
+
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
+		);
 
 		/**
 		 * Fires after an activity is deleted via the REST API.

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -497,8 +497,9 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	public function delete_item( $request ) {
 		$request->set_param( 'context', 'edit' );
 
+		// Get the group before it's deleted.
 		$group    = $this->get_group_object( $request );
-		$response = $this->prepare_item_for_response( $group, $request );
+		$previous = $this->prepare_item_for_response( $group, $request );
 
 		if ( ! groups_delete_group( $group->id ) ) {
 			return new WP_Error(
@@ -509,6 +510,15 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				)
 			);
 		}
+
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
+		);
 
 		/**
 		 * Fires after a group is deleted via the REST API.

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -668,7 +668,9 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
-		$thread = $this->get_thread_object( $request['id'] );
+		// Get the thread before it's deleted.
+		$thread   = $this->get_thread_object( $request['id'] );
+		$previous = $this->prepare_item_for_response( $thread, $request );
 
 		$user_id = bp_loggedin_user_id();
 		if ( ! empty( $request['user_id'] ) ) {
@@ -686,13 +688,14 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$retval = array(
-			$this->prepare_response_for_collection(
-				$this->prepare_item_for_response( $thread, $request )
-			),
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
 		);
-
-		$response = rest_ensure_response( $retval );
 
 		/**
 		 * Fires after a thread is deleted via the REST API.

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -436,8 +436,9 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
+		// Get the notification before it's deleted.
 		$notification = $this->get_notification_object( $request );
-		$response     = $this->prepare_item_for_response( $notification, $request );
+		$previous     = $this->prepare_item_for_response( $notification, $request );
 
 		if ( ! BP_Notifications_Notification::delete( array( 'id' => $notification->id ) ) ) {
 			return new WP_Error(
@@ -448,6 +449,15 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 				)
 			);
 		}
+
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
+		);
 
 		/**
 		 * Fires after a notification is deleted via the REST API.

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -338,7 +338,10 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 
 		// Get the field data before it's deleted.
 		$field_data = $this->get_xprofile_field_data_object( $field->id, $user->ID );
-		$previous   = $this->prepare_item_for_response( $field_data, $request );
+
+		// Set empty for the response.
+		$field_data->value = '';
+		$previous          = $this->prepare_item_for_response( $field_data, $request );
 
 		if ( ! $field_data->delete() ) {
 			return new WP_Error(

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -336,7 +336,9 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 
 		$user = bp_rest_get_user( $request['user_id'] );
 
+		// Get the field data before it's deleted.
 		$field_data = $this->get_xprofile_field_data_object( $field->id, $user->ID );
+		$previous   = $this->prepare_item_for_response( $field_data, $request );
 
 		if ( ! $field_data->delete() ) {
 			return new WP_Error(
@@ -348,16 +350,14 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		// Set empty for the response.
-		$field_data->value = '';
-
-		$retval = array(
-			$this->prepare_response_for_collection(
-				$this->prepare_item_for_response( $field_data, $request )
-			),
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
 		);
-
-		$response = rest_ensure_response( $retval );
 
 		/**
 		 * Fires after a XProfile data is deleted via the REST API.

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -494,7 +494,6 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 	public function delete_item( $request ) {
 		// Get the field group before it's deleted.
 		$field_group = $this->get_xprofile_field_group_object( $request );
-		$previous    = $this->prepare_item_for_response( $field_group, $request );
 
 		if ( empty( $field_group->id ) ) {
 			return new WP_Error(
@@ -517,6 +516,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 		}
 
 		// Build the response.
+		$previous = $this->prepare_item_for_response( $field_group, $request );
 		$response = new WP_REST_Response();
 		$response->set_data(
 			array(

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -492,7 +492,9 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
+		// Get the field group before it's deleted.
 		$field_group = $this->get_xprofile_field_group_object( $request );
+		$previous    = $this->prepare_item_for_response( $field_group, $request );
 
 		if ( empty( $field_group->id ) ) {
 			return new WP_Error(
@@ -514,13 +516,14 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$retval = array(
-			$this->prepare_response_for_collection(
-				$this->prepare_item_for_response( $field_group, $request )
-			),
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
 		);
-
-		$response = rest_ensure_response( $retval );
 
 		/**
 		 * Fires after a field group is deleted via the REST API.

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -727,9 +727,9 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertNotEmpty( $data );
+		$this->assertNotEmpty( $data['deleted'] );
 
-		$this->assertEquals( 'Deleted activity', $data['content']['raw'] );
+		$this->assertEquals( 'Deleted activity', $data['previous']['content']['raw'] );
 	}
 
 	/**

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -510,7 +510,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$data = $response->get_data();
 
-		$this->assertEquals( 'Deleted group', $data['description']['raw'] );
+		$this->assertEquals( 'Deleted group', $data['previous']['description']['raw'] );
 	}
 
 	/**
@@ -582,7 +582,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$data = $response->get_data();
 
-		$this->assertEquals( 'Deleted group', $data['description']['raw'] );
+		$this->assertEquals( 'Deleted group', $data['previous']['description']['raw'] );
 	}
 
 	public function test_prepare_item() {

--- a/tests/membership/test-group-membership-controller.php
+++ b/tests/membership/test-group-membership-controller.php
@@ -686,10 +686,8 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		foreach ( $all_data as $data ) {
-			$user = bp_rest_get_user( $data['id'] );
-			$this->assertFalse( groups_is_user_member( $user->ID, $g1 ) );
-		}
+		$user = bp_rest_get_user( $all_data['previous']['id'] );
+		$this->assertFalse( groups_is_user_member( $user->ID, $g1 ) );
 	}
 
 	/**
@@ -718,10 +716,8 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		foreach ( $all_data as $data ) {
-			$user = bp_rest_get_user( $data['id'] );
-			$this->assertFalse( groups_is_user_member( $user->ID, $g1 ) );
-		}
+		$user = bp_rest_get_user( $all_data['previous']['id'] );
+		$this->assertFalse( groups_is_user_member( $user->ID, $g1 ) );
 	}
 
 	/**
@@ -774,10 +770,8 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		foreach ( $all_data as $data ) {
-			$user = bp_rest_get_user( $data['id'] );
-			$this->assertFalse( groups_is_user_member( $user->ID, $g1 ) );
-		}
+		$user = bp_rest_get_user( $all_data['previous']['id'] );
+		$this->assertFalse( groups_is_user_member( $user->ID, $g1 ) );
 	}
 
 	/**

--- a/tests/notifications/test-controller.php
+++ b/tests/notifications/test-controller.php
@@ -316,7 +316,7 @@ class BP_Test_REST_Notifications_Endpoint extends WP_Test_REST_Controller_Testca
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		$this->check_notification_data( $notification, $all_data, 'view', $response->get_links() );
+		$this->check_notification_data( $notification, $all_data['previous'], 'view', $response->get_links() );
 	}
 
 	/**

--- a/tests/xprofile/test-data-controller.php
+++ b/tests/xprofile/test-data-controller.php
@@ -187,9 +187,9 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 		$this->assertNotEmpty( $data );
 
-		$this->assertEmpty( $data[0]['value']['unserialized'] );
+		$this->assertEmpty( $data['previous']['value']['unserialized'] );
 
-		$field_data = $this->endpoint->get_xprofile_field_data_object( $data[0]['field_id'], $data[0]['user_id'] );
+		$field_data = $this->endpoint->get_xprofile_field_data_object( $data['previous']['field_id'], $data['previous']['user_id'] );
 
 		$this->assertEmpty( $field_data->value );
 		$this->assertEmpty( $field_data->last_updated );
@@ -220,9 +220,9 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 		$this->assertNotEmpty( $data );
 
-		$this->assertEmpty( $data[0]['value']['unserialized'] );
+		$this->assertEmpty( $data['previous']['value']['unserialized'] );
 
-		$field_data = $this->endpoint->get_xprofile_field_data_object( $data[0]['field_id'], $data[0]['user_id'] );
+		$field_data = $this->endpoint->get_xprofile_field_data_object( $data['previous']['field_id'], $data['previous']['user_id'] );
 
 		$this->assertEmpty( $field_data->value );
 		$this->assertEmpty( $field_data->last_updated );
@@ -355,7 +355,6 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		// POST
 		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, $this->user ) );
 		$request->add_header( 'content-type', 'application/json' );
-		
 
 		$params = $this->set_field_data( array(
 			'foo_metadata_key' => $expected,

--- a/tests/xprofile/test-field-controller.php
+++ b/tests/xprofile/test-field-controller.php
@@ -330,7 +330,7 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		$this->check_field_data( $field, $all_data[0], 'view', $response->get_links() );
+		$this->check_field_data( $field, $all_data['previous'], 'view', $response->get_links() );
 	}
 
 	/**

--- a/tests/xprofile/test-group-controller.php
+++ b/tests/xprofile/test-group-controller.php
@@ -279,7 +279,7 @@ class BP_Test_REST_XProfile_Groups_Endpoint extends WP_Test_REST_Controller_Test
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		$this->check_group_data( $field_group, $all_data[0], 'view', $response->get_links() );
+		$this->check_group_data( $field_group, $all_data['previous'], 'view', $response->get_links() );
 	}
 
 	/**


### PR DESCRIPTION
As discussed during August 7th dev chat, I think it's important we harmonize how we build the responses of the endpoints `delete_item()` methods.

I've suggested to do just like the WP REST API does for this case. One good reason to do so is: our Members endpoint extends the WP Users one and already uses this specific way to build responses. See the extract of `WP_REST_Users_Controller->delete_item()` code below:

```php
		$result = wp_delete_user( $id, $reassign );

		if ( ! $result ) {
			return new WP_Error( 'rest_cannot_delete', __( 'The user cannot be deleted.' ), array( 'status' => 500 ) );
		}

		$response = new WP_REST_Response();
		$response->set_data(
			array(
				'deleted'  => true,
				'previous' => $previous->get_data(),
			)
		);
```

This PR is applying this to all endpoints except for the 2 ones @dcavins is currently working on in #206 