### PR TITLE
Improve Messages endpoint arguments

### DIFF
--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -744,7 +744,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			$user_id = $request['user_id'];
 		}
 
-		// Check the user is one of the recipients
+		// Check the user is one of the recipients.
 		$recipient_ids = wp_parse_id_list( wp_list_pluck( $thread->recipients, 'user_id' ) );
 
 		// Delete a thread.

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -414,7 +414,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @since 0.1.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function create_item( $request ) {
 		// Prepare the message or the reply arguments.

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -62,25 +62,19 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::READABLE ),
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
-					'args'                => array(
-						'message_id' => array(
-							'description'       => __( 'By default the latest message of the thread will be updated. Specify this message ID to edit another message of the thread.', 'buddypress' ),
-							'required'          => false,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-							'validate_callback' => 'rest_validate_request_arg',
-						),
-					),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::DELETABLE ),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
@@ -115,9 +109,14 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @return array Endpoint arguments.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
-		$args = WP_REST_Controller::get_endpoint_args_for_item_schema( $method );
+		$args                      = WP_REST_Controller::get_endpoint_args_for_item_schema( $method );
+		$args['id']['description'] = __( 'ID of the Messages Thread.', 'buddypress' );
 
 		if ( WP_REST_Server::CREATABLE === $method ) {
+			// Edit the Thread ID description and default properties.
+			$args['id']['description'] = __( 'ID of the Messages Thread. Required when replying to an existing Thread.', 'buddypress' );
+			$args['id']['default']     = 0;
+
 			// Add the sender_id argument.
 			$args['sender_id'] = array(
 				'description'       => __( 'The user ID of the Message sender.', 'buddypress' ),
@@ -135,16 +134,40 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 
 			// Edit message's properties.
 			$args['message']['type']        = 'string';
-			$args['message']['description'] = __( 'Content of the Message initializing the Thread.', 'buddypress' );
+			$args['message']['description'] = __( 'Content of the Message to add to the Thread.', 'buddypress' );
 
-			// Edit recipients properties
+			// Edit recipients properties.
 			$args['recipients']['items']             = array( 'type' => 'integer' );
 			$args['recipients']['sanitize_callback'] = 'wp_parse_id_list';
 			$args['recipients']['validate_callback'] = 'rest_validate_request_arg';
-			$args['recipients']['description']       =  __( 'The list of the recipients user IDs of the Message.', 'buddypress' );
+			$args['recipients']['description']       = __( 'The list of the recipients user IDs of the Message.', 'buddypress' );
 
 			// Remove unused properties for this transport method.
 			unset( $args['subject']['properties'], $args['message']['properties'] );
+
+		} else {
+			unset( $args['sender_id'], $args['subject'], $args['message'], $args['recipients'] );
+
+			if ( WP_REST_Server::EDITABLE === $method ) {
+				$args['message_id'] = array(
+					'description'       => __( 'By default the latest message of the thread will be updated. Specify this message ID to edit another message of the thread.', 'buddypress' ),
+					'required'          => false,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+					'validate_callback' => 'rest_validate_request_arg',
+				);
+			}
+
+			if ( WP_REST_Server::DELETABLE === $method ) {
+				$args['user_id'] = array(
+					'description'       => __( 'The user ID to remove from the thread', 'buddypress' ),
+					'required'          => false,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+					'validate_callback' => 'rest_validate_request_arg',
+					'default'           => bp_loggedin_user_id(),
+				);
+			}
 		}
 
 		return $args;
@@ -366,7 +389,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Create message.
+	 * Init a Messages Thread or add a reply to an existing Thread.
 	 *
 	 * @since 0.1.0
 	 *
@@ -374,9 +397,38 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function create_item( $request ) {
-		$prepared_thread = $this->prepare_item_for_database( $request );
+		// Prepare the message or the reply arguments.
+		$args = array(
+			'sender_id'  => $request['sender_id'] ? $request['sender_id'] : bp_loggedin_user_id(),
+			'thread_id'  => 0,
+			'subject'    => $request['subject'] ? $request['subject'] : false,
+			'content'    => $request['message'],
+			'recipients' => $request['recipients'],
+		);
 
-		if ( ! isset( $prepared_thread->recipients ) || ! $prepared_thread->recipients ) {
+		$error = new WP_Error(
+			'bp_rest_messages_create_failed',
+			__( 'There was an error trying to create the message.', 'buddypress' ),
+			array(
+				'status' => 500,
+			)
+		);
+
+		// Replying to an existing Thread ?
+		if ( $request['id'] ) {
+			// Try to get the thread.
+			$thread = $this->get_thread_object( $request['id'] );
+
+			// Validate the Thread exists.
+			if ( ! $thread->thread_id ) {
+				return $error;
+			}
+
+			$args['thread_id']  = (int) $thread->thread_id;
+			$args['recipients'] = wp_parse_id_list( wp_list_pluck( $thread->recipients, 'user_id' ) );
+		}
+
+		if ( ! $args['recipients'] ) {
 			return new WP_Error(
 				'bp_rest_messages_missing_recipients',
 				__( 'Please provide some recipients for your message or reply.', 'buddypress' ),
@@ -386,17 +438,12 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		// Create message.
-		$thread_id = messages_new_message( $prepared_thread );
+		// Create the message or the reply.
+		$thread_id = messages_new_message( $args );
 
+		// Validate it created a Thread or was added to it.
 		if ( ! $thread_id ) {
-			return new WP_Error(
-				'bp_rest_messages_create_failed',
-				__( 'There was an error trying to create the message.', 'buddypress' ),
-				array(
-					'status' => 500,
-				)
-			);
+			return $error;
 		}
 
 		// Make sure to get the newest message to update REST Additional fields.
@@ -464,7 +511,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Update one of the messages of the thread.
+	 * Update metadata for one of the messages of the thread.
 	 *
 	 * @since 0.1.0
 	 *
@@ -962,70 +1009,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Prepare a message/thread for create or update.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return stdClass|WP_Error Object or WP_Error.
-	 */
-	protected function prepare_item_for_database( $request ) {
-		$prepared_thread = new stdClass();
-		$schema          = $this->get_item_schema();
-
-		// By default, let's init a new Thread.
-		$prepared_thread->thread_id = false;
-
-		// If it's a reply, get the parent thread.
-		if ( $request['thread_id'] ) {
-			$thread = $this->get_thread_object( $request['thread_id'] );
-
-			if ( ! empty( $schema['properties']['id'] ) && ! empty( $thread->thread_id ) ) {
-				$prepared_thread->thread_id = $thread->thread_id;
-			}
-		}
-
-		// Defaults to current user.
-		$prepared_thread->sender_id = bp_loggedin_user_id();
-		if ( $request['sender_id'] ) {
-			$prepared_thread->sender_id = $request['sender_id'];
-		} elseif ( ! empty( $schema['properties']['last_sender_id'] ) && ! empty( $thread->sender_id ) ) {
-			$prepared_thread->sender_id = $thread->sender_id;
-		}
-
-		// Note to self: the content was not one of the schema properties
-		if ( ! empty( $schema['properties']['message'] ) && ! empty( $thread->last_message_content ) ) {
-			$prepared_thread->last_message_content = $thread->last_message_content;
-		} else {
-			$prepared_thread->content = $request['message'];
-		}
-
-		if ( ! empty( $schema['properties']['subject'] ) && ! empty( $thread->last_message_subject ) ) {
-			$prepared_thread->last_message_subject = $thread->last_message_subject;
-		} elseif ( ! empty( $request['subject'] ) ) {
-			$prepared_thread->subject = $request['subject'];
-		} else {
-			$prepared_thread->subject = false;
-		}
-
-		if ( ! empty( $request['recipients'] ) ) {
-			$prepared_thread->recipients = $request['recipients'];
-		} elseif ( isset( $thread->recipients ) && $thread->recipients ) {
-			$prepared_thread->recipients = wp_parse_id_list( wp_list_pluck( $thread->recipients, 'user_id' ) );
-		}
-
-		/**
-		 * Filters a thread before it is inserted or updated via the REST API.
-		 *
-		 * @since 0.1.0
-		 *
-		 * @param stdClass        $prepared_thread An object prepared for inserting or updating the database.
-		 * @param WP_REST_Request $request         Request object.
-		 */
-		return apply_filters( 'bp_rest_messages_pre_save_value', $prepared_thread, $request );
-	}
-
-	/**
 	 * Get thread object.
 	 *
 	 * @since 0.1.0
@@ -1065,7 +1048,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 				'id'                  => array(
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'A unique numeric ID for the Thread.', 'buddypress' ),
-					'readonly'    => true,
 					'type'        => 'integer',
 				),
 				'message_id'          => array(
@@ -1085,8 +1067,8 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 					'description' => __( 'Title of the latest message of the Thread.', 'buddypress' ),
 					'type'        => 'object',
 					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						'sanitize_callback' => null,
+						'validate_callback' => null,
 					),
 					'properties'  => array(
 						'raw'      => array(
@@ -1110,8 +1092,8 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 					'type'        => 'object',
 					'readonly'    => true,
 					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						'sanitize_callback' => null,
+						'validate_callback' => null,
 					),
 					'properties'  => array(
 						'raw'      => array(
@@ -1132,8 +1114,8 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 					'type'        => 'object',
 					'required'    => true,
 					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						'sanitize_callback' => null,
+						'validate_callback' => null,
 					),
 					'properties'  => array(
 						'raw'      => array(
@@ -1175,7 +1157,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'The list of recipient User Objects involved into the Thread.', 'buddypress' ),
 					'type'        => 'array',
-					'required'    => true,
 					'items'       => array(
 						'type' => 'object',
 					),

--- a/tests/messages/test-controller.php
+++ b/tests/messages/test-controller.php
@@ -706,6 +706,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_query_params(
 			array(
 				'id'         => $m1->thread_id,
+				'sender_id'  => $u1,
 				'message'    => 'Taz',
 				'bar_field'  => $expected,
 			)

--- a/tests/messages/test-controller.php
+++ b/tests/messages/test-controller.php
@@ -23,6 +23,13 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 		if ( ! $this->server ) {
 			$this->server = rest_get_server();
 		}
+
+		$this->old_current_user = get_current_user_id();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->bp->set_current_user( $this->old_current_user );
 	}
 
 	public function test_register_routes() {
@@ -344,6 +351,12 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->bp->set_current_user( $this->user );
 
 		$request  = new WP_REST_Request( 'DELETE', $this->endpoint_url . '/' . $m->thread_id );
+		$request->set_query_params(
+			array(
+				'user_id' => $u2,
+			)
+		);
+
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/messages/test-controller.php
+++ b/tests/messages/test-controller.php
@@ -206,7 +206,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 				'sender_id'  => $this->user,
 				'recipients' => [ $u ],
 				'subject'    => 'Foo',
-				'content'    => 'Content',
+				'message'    => 'Content',
 			)
 		);
 
@@ -237,7 +237,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 				'sender_id'  => $this->user,
 				'recipients' => [ $u ],
 				'subject'    => 'Foo',
-				'content'    => 'Content',
+				'message'    => 'Content',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -280,7 +280,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 			array(
 				'sender_id' => $this->user,
 				'subject'   => 'Foo',
-				'content'   => 'Content',
+				'message'   => 'Content',
 			)
 		);
 
@@ -645,7 +645,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 				'sender_id'  => $this->user,
 				'recipients' => [ $u ],
 				'subject'    => 'Foo',
-				'content'    => 'Bar',
+				'message'    => 'Bar',
 				'foo_field'  => $expected,
 			)
 		);
@@ -692,8 +692,8 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'POST', $this->endpoint_url );
 		$request->set_query_params(
 			array(
-				'thread_id'  => $m1->thread_id,
-				'content'    => 'Taz',
+				'id'         => $m1->thread_id,
+				'message'    => 'Taz',
 				'bar_field'  => $expected,
 			)
 		);


### PR DESCRIPTION
1. Edit the item schema to be able to use it for CREATABLE/EDITABLE/DELETABLE transport methods.
2. Use `BP_REST_Messages_Endpoint->get_endpoint_args_for_item_schema()` to adjust arguments properties.
3. Remove `BP_REST_Messages_Endpoint->prepare_item_for_database()`: as `BP_REST_Messages_Endpoint->update_item()` is only editing metadata, it was only used by the `create_item()` method.
4. Simplify how the arguments for `messages_new_message()` are generated in the `create_item()` method.
5. Adapt Messages Unit tests accordingly.

The [Messages Endpoints documentation](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/private-messaging/) has been written taking these changes in account.