### PR TITLE
Improve the Group Membership Controller

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -70,6 +70,12 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => $this->get_collection_params(),
 				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_method( WP_REST_Server::CREATABLE ),
+				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
@@ -87,12 +93,6 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 						'description' => __( 'A unique numeric ID for the Group Member.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_item' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => $this->get_endpoint_args_for_method( WP_REST_Server::CREATABLE ),
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -142,6 +142,15 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 				'sanitize_callback' => 'sanitize_key',
 				'validate_callback' => 'rest_validate_request_arg',
 			);
+
+			if ( WP_REST_Server::CREATABLE === $method ) {
+				$schema          = $this->get_item_schema();
+				$args['user_id'] = array_merge( $schema['properties']['id'], array(
+					'description' => __( 'A unique numeric ID for the Member to add to the Group.', 'buddypress' ),
+					'default'     => bp_loggedin_user_id(),
+					'readonly'    => false,
+				) );
+			}
 
 			if ( WP_REST_Server::EDITABLE === $method ) {
 				$filer_key = 'update_item';

--- a/tests/membership/test-group-membership-controller.php
+++ b/tests/membership/test-group-membership-controller.php
@@ -29,6 +29,13 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		if ( ! $this->server ) {
 			$this->server = rest_get_server();
 		}
+
+		$this->old_current_user = get_current_user_id();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->bp->set_current_user( $this->old_current_user );
 	}
 
 	public function test_register_routes() {
@@ -37,13 +44,13 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		// Main.
 		$this->assertArrayHasKey( $endpoint, $routes );
-		$this->assertCount( 1, $routes[ $endpoint ] );
+		$this->assertCount( 2, $routes[ $endpoint ] );
 
 		// Single.
 		$single_endpoint = $endpoint . '/(?P<user_id>[\d]+)';
 
 		$this->assertArrayHasKey( $single_endpoint, $routes );
-		$this->assertCount( 3, $routes[ $single_endpoint ] );
+		$this->assertCount( 2, $routes[ $single_endpoint ] );
 	}
 
 	/**
@@ -199,8 +206,11 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $g . '/members/' . $u );
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $g . '/members' );
 		$request->set_param( 'context', 'view' );
+		$request->set_query_params( array(
+			'user_id' => $u,
+		) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -218,8 +228,12 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		$this->bp->set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $this->group_id . '/members/' . $u );
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $this->group_id . '/members' );
 		$request->set_param( 'context', 'edit' );
+		$request->set_query_params( array(
+			'user_id' => $u,
+		) );
+
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -243,8 +257,11 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $this->group_id . '/members/' . $u );
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $this->group_id . '/members' );
 		$request->set_param( 'context', 'view' );
+		$request->set_query_params( array(
+			'user_id' => $u,
+		) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -272,8 +289,11 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $g1 . '/members/' . $u );
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $g1 . '/members' );
 		$request->set_param( 'context', 'view' );
+		$request->set_query_params( array(
+			'user_id' => $u,
+		) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_group_member_failed_to_join', $response, 500 );
@@ -291,8 +311,11 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		$this->bp->set_current_user( $u );
 
-		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $g1 . '/members/' . $u );
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $g1 . '/members' );
 		$request->set_param( 'context', 'view' );
+		$request->set_query_params( array(
+			'user_id' => $u,
+		) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_group_member_failed_to_join', $response, 500 );
@@ -307,8 +330,11 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 
 		$this->bp->set_current_user( $u1 );
 
-		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $this->group_id . '/members/' . $u2 );
+		$request = new WP_REST_Request( 'POST', $this->endpoint_url . $this->group_id . '/members' );
 		$request->set_param( 'context', 'view' );
+		$request->set_query_params( array(
+			'user_id' => $u2,
+		) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );


### PR DESCRIPTION
The route to create a new membership should be consistent with what we do in all other endpoints. Thats is to say: do not pass the user ID as the last part of the route. In other words: instead of using `/buddypress/v1/groups/<group_id>/members/<user_id>` we should be using `/buddypress/v1/groups/<group_id>/members` and pass the `user_id` into the request arguments.

This PR brings this improvement. It also adapts the unit tests.

_NB: on a site note, the REST Server used into the unit tests is not setting the current user at the time it fetches the routes arguments. This means, unlike what happens on the regular WP REST SERVER, the default value set to `bp_loggedin_user_id()` is `0` althought the current user is defined. That is why I added the `user_id` request argument on all `create_item` tests._

I updated the [documentation](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/user-groups/group-membership/#add-a-specific-member-into-a-group) to take in account this change.