### PR TITLE
Invitations: Take current user into account when deleting requests an…

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -587,7 +587,21 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 	 */
 	public function delete_item( $request ) {
 		$group_request = $this->fetch_single_invite( $request['request_id'] );
-		$success       = groups_reject_membership_request( false, $group_request->user_id, $group_request->item_id );
+
+		/**
+		 * If this change is being initiated by the requesting user,
+		 * use the `delete` function.
+		 */
+		if ( bp_loggedin_user_id() === $group_request->user_id ) {
+			$success = groups_delete_membership_request( false, $group_request->user_id, $group_request->item_id );
+		/**
+		 * Otherwise, this change is being initiated by a group admin or site admin,
+		 * and we should use the `reject` function.
+		 */
+		} else {
+			$success = groups_reject_membership_request( false, $group_request->user_id, $group_request->item_id );
+		}
+
 		if ( ! $success ) {
 			return new WP_Error(
 				'bp_rest_group_membership_requests_cannot_delete_item',


### PR DESCRIPTION
…d invitations.

BuddyPress offers a variety of delete functions for invitations and requests, representing different situations.
• `groups_uninvite_user()`
• `groups_reject_invite()`
• `groups_delete_invite()`
• `groups_reject_membership_request()`
• `groups_delete_membership_request()`

I'm assuming that the situation is driven by who is doing the deleting. In this patch, we compare the current user to the subject user of the invitation or request to determine whether the invitation or request is being withdrawn or rejected.