### PR TITLE
Improve group invites/requests DELETE response.

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -586,7 +586,11 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
+		$request->set_param( 'context', 'edit' );
+
 		$group_request = $this->fetch_single_invite( $request['request_id'] );
+		// Set the invite response before it is deleted.
+		$previous = $this->prepare_item_for_response( $group_request, $request );
 
 		/**
 		 * If this change is being initiated by the requesting user,
@@ -612,15 +616,14 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$invite = new BP_Invitation( $request['request_id'] );
-
-		$retval = array(
-			$this->prepare_response_for_collection(
-				$this->prepare_item_for_response( $invite, $request )
-			),
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
 		);
-
-		$response = rest_ensure_response( $retval );
 
 		$user  = bp_rest_get_user( $group_request->user_id );
 		$group = $this->groups_endpoint->get_group_object( $group_request->item_id );

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -587,7 +587,21 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 	 */
 	public function delete_item( $request ) {
 		$group_request = $this->fetch_single_invite( $request['request_id'] );
-		$success       = groups_reject_membership_request( false, $group_request->user_id, $group_request->item_id );
+
+		/**
+		 * If this change is being initiated by the requesting user,
+		 * use the `delete` function.
+		 */
+		if ( bp_loggedin_user_id() === $group_request->user_id ) {
+			$success = groups_delete_membership_request( false, $group_request->user_id, $group_request->item_id );
+		/**
+		 * Otherwise, this change is being initiated by a group admin or site admin,
+		 * and we should use the `reject` function.
+		 */
+		} else {
+			$success = groups_reject_membership_request( false, $group_request->user_id, $group_request->item_id );
+		}
+
 		if ( ! $success ) {
 			return new WP_Error(
 				'bp_rest_group_membership_requests_cannot_delete_item',

--- a/tests/groups/test-group-invites-controller.php
+++ b/tests/groups/test-group-invites-controller.php
@@ -604,8 +604,8 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $invite_id, $all_data['previous']['id']);
 	}
 
 	/**
@@ -629,8 +629,8 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $invite_id, $all_data['previous']['id']);
 	}
 
 	/**
@@ -657,8 +657,8 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $invite_id, $all_data['previous']['id']);
 	}
 
 	/**
@@ -686,8 +686,8 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $invite_id, $all_data['previous']['id']);
 	}
 
 	/**

--- a/tests/membership/test-group-membership-request-controller.php
+++ b/tests/membership/test-group-membership-request-controller.php
@@ -519,7 +519,8 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $request_id, $all_data['previous']['id']);
 	}
 
 	/**
@@ -538,7 +539,8 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $request_id, $all_data['previous']['id']);
 	}
 
 	/**
@@ -557,7 +559,8 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$this->assertEquals( 200, $response->get_status() );
 
 		$all_data = $response->get_data();
-		$this->assertTrue( 0 === $all_data[0]['id'] );
+		$this->assertTrue( $all_data['deleted'] );
+		$this->assertEquals( $request_id, $all_data['previous']['id']);
 	}
 
 	/**


### PR DESCRIPTION
Improve the response to `delete` requests by adding a `deleted` boolean and putting the now-deleted invite data into `previous`, similar to the pattern used elsewhere in the REST API.