### PR TITLE
Improve the Member Avatar Endpoint

### DIFF
--- a/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -318,7 +318,7 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 
 		if ( ! bp_get_user_has_avatar( $user_id ) ) {
 			return new WP_Error(
-				'bp_rest_attachments_member_avatar_no_uploaded avatar',
+				'bp_rest_attachments_member_avatar_no_uploaded_avatar',
 				__( 'Sorry, there are no uploaded avatars for this user on this site.', 'buddypress' ),
 				array(
 					'status' => 404,

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -65,6 +65,12 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<user_id>[\d]+)/avatar',
 			array(
+				'args'   => array(
+					'user_id' => array(
+						'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
@@ -75,6 +81,14 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'action' => array(
+							'description' => __( 'The upload action used when uploading a file.', 'buddypress' ),
+							'type'        => 'string',
+							'required'    => true,
+							'default'     => $this->avatar_instance->action,
+						),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
@@ -95,18 +109,25 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
-		$avatar = bp_core_fetch_avatar(
-			array(
-				'object'  => $this->object,
-				'type'    => $request['type'],
-				'item_id' => (int) $this->user->ID,
-				'html'    => (bool) $request['html'],
-				'alt'     => $request['alt'],
-				'no_grav' => (bool) $request['no_gravatar'],
-			)
-		);
+		$args = array();
 
-		if ( empty( $avatar ) ) {
+		foreach ( array( 'full', 'thumb' ) as $type ) {
+			$args[ $type ] = bp_core_fetch_avatar(
+				array(
+					'object'  => $this->object,
+					'type'    => $type,
+					'item_id' => (int) $this->user->ID,
+					'html'    => (bool) $request['html'],
+					'alt'     => $request['alt'],
+					'no_grav' => (bool) $request['no_gravatar'],
+				)
+			);
+		}
+
+		// Get the avatar object.
+		$avatar = $this->get_avatar_object( $args );
+
+		if ( ! $avatar->full && ! $avatar->thumb ) {
 			return new WP_Error(
 				'bp_rest_attachments_member_avatar_no_image',
 				__( 'Sorry, there was a problem fetching the avatar.', 'buddypress' ),
@@ -293,20 +314,38 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 	 */
 	public function delete_item( $request ) {
 		$request->set_param( 'context', 'edit' );
+		$user_id = (int) $this->user->ID;
 
-		$avatar = bp_core_fetch_avatar(
-			array(
-				'object'  => $this->object,
-				'item_id' => $this->user->ID,
-				'html'    => false,
-				'type'    => 'full',
-			)
-		);
+		if ( ! bp_get_user_has_avatar( $user_id ) ) {
+			return new WP_Error(
+				'bp_rest_attachments_member_avatar_no_uploaded avatar',
+				__( 'Sorry, there are no uploaded avatars for this user on this site.', 'buddypress' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		$args = array();
+
+		foreach ( array( 'full', 'thumb' ) as $type ) {
+			$args[ $type ] = bp_core_fetch_avatar(
+				array(
+					'object'  => $this->object,
+					'type'    => $type,
+					'item_id' => $user_id,
+					'html'    => false,
+				)
+			);
+		}
+
+		// Get the avatar object before deleting it.
+		$avatar = $this->get_avatar_object( $args );
 
 		$deleted = bp_core_delete_existing_avatar(
 			array(
 				'object'  => $this->object,
-				'item_id' => (int) $this->user->ID,
+				'item_id' => $user_id,
 			)
 		);
 
@@ -374,16 +413,10 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $avatar, $request ) {
-		if ( is_string( $avatar ) ) {
-			$data = array(
-				'image' => $avatar,
-			);
-		} else {
-			$data = array(
-				'full'  => $avatar->full,
-				'thumb' => $avatar->thumb,
-			);
-		}
+		$data = array(
+			'full'  => $avatar->full,
+			'thumb' => $avatar->thumb,
+		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
@@ -421,12 +454,14 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Full size of the image file.', 'buddypress' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 				'thumb' => array(
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Thumb size of the image file.', 'buddypress' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 			),
@@ -453,15 +488,6 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 
 		// Removing unused params.
 		unset( $params['search'], $params['page'], $params['per_page'] );
-
-		$params['type'] = array(
-			'description'       => __( 'Whether you would like the `full` or the smaller `thumb`.', 'buddypress' ),
-			'default'           => 'thumb',
-			'type'              => 'string',
-			'enum'              => array( 'thumb', 'full' ),
-			'sanitize_callback' => 'sanitize_key',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
 
 		$params['html'] = array(
 			'description'       => __( 'Whether to return an <img> HTML element, vs a raw URL to an avatar.', 'buddypress' ),

--- a/includes/bp-attachments/classes/trait-attachments.php
+++ b/includes/bp-attachments/classes/trait-attachments.php
@@ -16,6 +16,31 @@ defined( 'ABSPATH' ) || exit;
 trait BP_REST_Attachments {
 
 	/**
+	 * Returns the avatar object.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param array $args {
+	 *     An array of arguments to build the Avatar object.
+	 *
+	 *     @type string $full  The url to the full version of the avatar.
+	 *     @type string $thumb The url to the thumb version of the avatar.
+	 * }
+	 * @return object The avatar object.
+	 */
+	protected function get_avatar_object( $args = array() ) {
+		$avatar_object = array_intersect_key(
+			$args,
+			array(
+				'full'  => '',
+				'thumb' => '',
+			)
+		);
+
+		return (object) $avatar_object;
+	}
+
+	/**
 	 * Avatar upload from File.
 	 *
 	 * @since 0.1.0
@@ -37,10 +62,7 @@ trait BP_REST_Attachments {
 		}
 
 		$avatar_attachment = $this->avatar_instance;
-
-		// Needed to avoid 'Invalid form submission' error.
-		$_POST['action'] = $avatar_attachment->action;
-		$avatar_original = $avatar_attachment->upload( $files, $upload_main_dir );
+		$avatar_original   = $avatar_attachment->upload( $files, $upload_main_dir );
 
 		// Bail early in case of an error.
 		if ( ! empty( $avatar_original['error'] ) ) {
@@ -68,8 +90,8 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_avatar_error",
 				sprintf(
-					/* translators: %$1s and %$2s is replaced with the correct sizes. */
-					__( 'You have selected an image that is smaller than recommended. For best results, upload a picture larger than %$1s x %$2s pixels.', 'buddypress' ),
+					/* translators: %1$s and %2$s is replaced with the correct sizes. */
+					__( 'You have selected an image that is smaller than recommended. For best results, upload a picture larger than %1$s x %2$s pixels.', 'buddypress' ),
 					bp_core_avatar_full_width(),
 					bp_core_avatar_full_height()
 				),
@@ -88,16 +110,19 @@ trait BP_REST_Attachments {
 			return $cropped;
 		}
 
-		// Build response object.
-		$avatar_object = new stdClass();
+		// Set the arguments for the avatar.
+		$args = array();
 		foreach ( [ 'full', 'thumb' ] as $key_type ) {
 
 			// Update path with an url.
 			$url = str_replace( bp_core_avatar_upload_path(), '', $cropped[ $key_type ] );
 
 			// Set image url to its size/type.
-			$avatar_object->{$key_type} = bp_core_avatar_url() . $url;
+			$args[ $key_type ] = bp_core_avatar_url() . $url;
 		}
+
+		// Build response object.
+		$avatar_object = $this->get_avatar_object( $args );
 
 		if ( file_exists( $avatar_original['file'] ) ) {
 			unlink( $avatar_original['file'] );

--- a/tests/attachments/test-member-avatar-controller.php
+++ b/tests/attachments/test-member-avatar-controller.php
@@ -214,7 +214,7 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		$request  = new WP_REST_Request( 'DELETE', sprintf( $this->endpoint_url . '%d/avatar', $this->user_id ) );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_attachments_member_avatar_delete_failed', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_attachments_member_avatar_no_uploaded_avatar', $response, 404 );
 	}
 
 	/**

--- a/tests/attachments/test-member-avatar-controller.php
+++ b/tests/attachments/test-member-avatar-controller.php
@@ -23,6 +23,13 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		if ( ! $this->server ) {
 			$this->server = rest_get_server();
 		}
+
+		$this->old_current_user = get_current_user_id();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->bp->set_current_user( $this->old_current_user );
 	}
 
 	public function test_register_routes() {
@@ -58,7 +65,7 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		$this->assertNotEmpty( $all_data[0]['image'] );
+		$this->assertTrue( isset( $all_data[0]['full'] ) && isset( $all_data[0]['thumb'] ) );
 	}
 
 	/**
@@ -74,7 +81,7 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		$all_data = $response->get_data();
 		$this->assertNotEmpty( $all_data );
 
-		$this->assertNotEmpty( $all_data[0]['image'] );
+		$this->assertTrue( isset( $all_data[0]['full'] ) && isset( $all_data[0]['thumb'] ) );
 	}
 
 	/**
@@ -90,7 +97,65 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 	 * @group create_item
 	 */
 	public function test_create_item() {
-		return true;
+		$reset_files = $_FILES;
+		$reset_post  = $_POST;
+		$image_file  = trailingslashit( buddypress()->plugin_dir ) . 'bp-core/images/mystery-man.jpg';
+
+		$this->bp->set_current_user( $this->user_id );
+
+		add_filter( 'pre_move_uploaded_file', array( $this, 'copy_file' ), 10, 3 );
+		add_filter( 'bp_core_avatar_dimension', array( $this, 'return_100' ), 10, 1 );
+
+		$_FILES['file'] = array(
+			'tmp_name' => $image_file,
+			'name'     => 'mystery-man.jpg',
+			'type'     => 'image/jpeg',
+			'error'    => 0,
+			'size'     => filesize( $image_file ),
+		);
+
+		$_POST['action'] = 'bp_avatar_upload';
+
+		$request  = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/avatar', $this->user_id ) );
+		$request->set_param( 'action', $_POST['action'] );
+		$request->set_file_params( $_FILES );
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'pre_move_uploaded_file', array( $this, 'copy_file' ), 10, 3 );
+		remove_filter( 'bp_core_avatar_dimension', array( $this, 'return_100' ), 10, 1 );
+
+		$all_data = $response->get_data();
+		$avatar = reset( $all_data );
+
+		$this->assertSame( $avatar, array(
+			'full'  => bp_core_fetch_avatar(
+				array(
+					'object'  => 'user',
+					'type'    => 'full',
+					'item_id' => $this->user_id,
+					'html'    => false,
+				)
+			),
+			'thumb' => bp_core_fetch_avatar(
+				array(
+					'object'  => 'user',
+					'type'    => 'thumb',
+					'item_id' => $this->user_id,
+					'html'    => false,
+				)
+			),
+		) );
+
+		$_FILES = $reset_files;
+		$_POST = $reset_post;
+	}
+
+	public function copy_file( $return = null, $file, $new_file ) {
+		return @copy( $file['tmp_name'], $new_file );
+	}
+
+	public function return_100( $size ) {
+		return 100;
 	}
 
 	/**


### PR DESCRIPTION
- Make sure the get_item response is consistent with the item schema. That is to say: always return the full and thumb version of the avatar.
- Add the `action` argument to the CREATABLE transport method: `BP_REST_Attachments` should not override the $_POST global.
- Add a unit test for the `create_item` method
- Fix the wrong use of sprintf in `BP_REST_Attachments->upload_avatar_from_file()`
- Introduce `BP_REST_Attachments->get_avatar_object()` to build the avatar object

Write the [documentation](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/attachments/member-avatar/) about this controller taking in account these changes.