### PR TITLE
The action parameter for avatar uploads need to be into the form data

### DIFF
--- a/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php
@@ -91,14 +91,6 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => array(
-						'action' => array(
-							'description' => __( 'The upload action used when uploading a file.', 'buddypress' ),
-							'type'        => 'string',
-							'required'    => true,
-							'default'     => $this->avatar_instance->action,
-						),
-					),
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -81,14 +81,6 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => array(
-						'action' => array(
-							'description' => __( 'The upload action used when uploading a file.', 'buddypress' ),
-							'type'        => 'string',
-							'required'    => true,
-							'default'     => $this->avatar_instance->action,
-						),
-					),
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,

--- a/tests/attachments/test-group-avatar-controller.php
+++ b/tests/attachments/test-group-avatar-controller.php
@@ -119,7 +119,6 @@ class BP_Test_REST_Attachments_Group_Avatar_Endpoint extends WP_Test_REST_Contro
 		$_POST['action'] = 'bp_avatar_upload';
 
 		$request  = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/avatar', $this->group_id ) );
-		$request->set_param( 'action', $_POST['action'] );
 		$request->set_file_params( $_FILES );
 		$response = rest_get_server()->dispatch( $request );
 

--- a/tests/attachments/test-member-avatar-controller.php
+++ b/tests/attachments/test-member-avatar-controller.php
@@ -117,7 +117,6 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		$_POST['action'] = 'bp_avatar_upload';
 
 		$request  = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/avatar', $this->user_id ) );
-		$request->set_param( 'action', $_POST['action'] );
 		$request->set_file_params( $_FILES );
 		$response = rest_get_server()->dispatch( $request );
 


### PR DESCRIPTION
Documentation has been updated accordingly:
- [Group Avatar](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/attachments/group-avatar/#example-of-use-2)
- [Member Avatar](https://imath-buddydocs.pf1.wpserveur.net/bp-rest-api/reference/attachments/member-avatar/#example-of-use-2)