### PR TITLE
Translation strings shouldn't use a placeholder for an untranslated string

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -501,13 +501,16 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 			$loggedin_user_id = bp_loggedin_user_id();
 			if ( true === $retval && in_array( $request['action'], [ 'ban', 'unban', 'promote', 'demote' ], true ) ) {
 				if ( ! groups_is_user_admin( $loggedin_user_id, $group->id ) && ! groups_is_user_mod( $loggedin_user_id, $group->id ) ) {
+					$messages = array(
+						'ban'     => __( 'Sorry, you are not allowed to ban this group member.', 'buddypress' ),
+						'unban'   => __( 'Sorry, you are not allowed to unban this group member.', 'buddypress' ),
+						'promote' => __( 'Sorry, you are not allowed to promote this group member.', 'buddypress' ),
+						'demote'  => __( 'Sorry, you are not allowed to demote this group member.', 'buddypress' ),
+					);
+
 					$retval = new WP_Error(
 						'bp_rest_group_member_cannot_' . $request['action'],
-						sprintf(
-							/* translators: %1$s is replaced with the action. */
-							__( 'Sorry, you are not allowed to %s this group member.', 'buddypress' ),
-							esc_attr( $request['action'] )
-						),
+						$messages[ $request['action'] ],
 						array(
 							'status' => rest_authorization_required_code(),
 						)


### PR DESCRIPTION
The membership actions are not translated as a result, the error message cannot be fully translated.