### PR TITLE
Fix some i18n issues

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -574,7 +574,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && empty( $activity->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid activity id.', 'buddypress' ),
+				__( 'Invalid activity ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -687,7 +687,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && empty( $activity->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid activity id.', 'buddypress' ),
+				__( 'Invalid activity ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -749,7 +749,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( empty( $activity->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid activity id.', 'buddypress' ),
+				__( 'Invalid activity ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php
@@ -175,7 +175,7 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 		if ( ! $this->group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -272,7 +272,7 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 		) {
 			$retval = new WP_Error(
 				'bp_rest_authorization_required',
-				__( 'Sorry, you are unauthorized to perform this action.', 'buddypress' ),
+				__( 'Sorry, you are not authorized to perform this action.', 'buddypress' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -166,7 +166,7 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $this->user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)

--- a/includes/bp-attachments/classes/trait-attachments.php
+++ b/includes/bp-attachments/classes/trait-attachments.php
@@ -172,8 +172,8 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_avatar_upload_error",
 				sprintf(
-					/* translators: %1$s is replaced with error message. */
-					__( 'Upload failed! Error was: %1$s', 'buddypress' ),
+					/* translators: %s is replaced with error message. */
+					__( 'Upload failed! Error was: %s', 'buddypress' ),
 					$img_dir->get_error_message()
 				),
 				array(

--- a/includes/bp-attachments/classes/trait-attachments.php
+++ b/includes/bp-attachments/classes/trait-attachments.php
@@ -172,8 +172,8 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_avatar_upload_error",
 				sprintf(
-					/* translators: %$1s is replaced with error message. */
-					__( 'Upload failed! Error was: %$1s', 'buddypress' ),
+					/* translators: %1$s is replaced with error message. */
+					__( 'Upload failed! Error was: %1$s', 'buddypress' ),
 					$img_dir->get_error_message()
 				),
 				array(
@@ -248,7 +248,7 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_avatar_crop_error",
 				sprintf(
-					/* translators: %$1s is replaced with object type. */
+					/* translators: %s is replaced with object type. */
 					__( 'There was a problem cropping your %s photo.', 'buddypress' ),
 					$this->object
 				),

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -208,7 +208,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && $request['group_id'] && ! $group instanceof BP_Groups_Group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -219,7 +219,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && $user_id_arg && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -230,7 +230,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && $request['inviter_id'] && ! $inviter instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -328,7 +328,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $invite ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invite_invalid_id',
-				__( 'Invalid group invitation id.', 'buddypress' ),
+				__( 'Invalid group invitation ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -458,7 +458,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && empty( $group->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -468,7 +468,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ( empty( $user->ID ) || empty( $inviter->ID ) || $user->ID === $inviter->ID ) ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -573,7 +573,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $invite ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invite_invalid_id',
-				__( 'Invalid group invitation id.', 'buddypress' ),
+				__( 'Invalid group invitation ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -699,7 +699,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $invite ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invite_invalid_id',
-				__( 'Invalid group invitation id.', 'buddypress' ),
+				__( 'Invalid group invitation ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -310,7 +310,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_group_member_invalid_id',
-				__( 'Invalid group member id.', 'buddypress' ),
+				__( 'Invalid group member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -321,7 +321,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group instanceof BP_Groups_Group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -477,7 +477,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_group_member_invalid_id',
-				__( 'Invalid group member id.', 'buddypress' ),
+				__( 'Invalid group member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -488,7 +488,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group instanceof BP_Groups_Group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -614,7 +614,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			return new WP_Error(
 				'bp_rest_group_member_invalid_id',
-				__( 'Invalid group member id.', 'buddypress' ),
+				__( 'Invalid group member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -625,7 +625,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group instanceof BP_Groups_Group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -204,7 +204,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && $request['group_id'] && ! $group instanceof BP_Groups_Group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -215,7 +215,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && $user_id_arg && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -303,7 +303,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group_request ) {
 			$retval = new WP_Error(
 				'bp_rest_group_membership_requests_invalid_id',
-				__( 'Invalid group membership request id.', 'buddypress' ),
+				__( 'Invalid group membership request ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -435,7 +435,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_group_member_invalid_id',
-				__( 'Invalid user id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -446,7 +446,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group instanceof BP_Groups_Group ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -553,7 +553,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group_request ) {
 			$retval = new WP_Error(
 				'bp_rest_group_membership_requests_invalid_id',
-				__( 'Invalid group membership request id.', 'buddypress' ),
+				__( 'Invalid group membership request ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -679,7 +679,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $group_request ) {
 			$retval = new WP_Error(
 				'bp_rest_group_membership_requests_invalid_id',
-				__( 'Invalid group membership request id.', 'buddypress' ),
+				__( 'Invalid group membership request ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -237,7 +237,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		if ( empty( $group->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -441,7 +441,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && empty( $group->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -545,7 +545,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && empty( $group->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
-				__( 'Invalid group id.', 'buddypress' ),
+				__( 'Invalid group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -1001,7 +1001,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				),
 				'enable_forum'       => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the Group has a forum or not.', 'buddypress' ),
+					'description' => __( 'Whether the Group has a forum enabled or not.', 'buddypress' ),
 					'type'        => 'boolean',
 				),
 				'parent_id'          => array(

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -140,7 +140,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		if ( ! is_user_logged_in() ) {
 			$retval = new WP_Error(
 				'bp_rest_authorization_required',
-				__( 'Sorry, you are not allowed to view members', 'buddypress' ),
+				__( 'Sorry, you are not allowed to view members.', 'buddypress' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)
@@ -152,7 +152,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -229,7 +229,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		if ( ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -597,7 +597,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'id'                 => array(
-					'description' => __( 'Unique identifier for the member.', 'buddypress' ),
+					'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
 					'type'        => 'integer',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
@@ -626,7 +626,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'readonly'    => true,
 				),
 				'user_login'         => array(
-					'description' => __( 'An alphanumeric identifier for the member.', 'buddypress' ),
+					'description' => __( 'An alphanumeric identifier for the Member.', 'buddypress' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'required'    => true,
@@ -767,7 +767,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		);
 
 		$params['include'] = array(
-			'description'       => __( 'Ensure result set include specific IDs.', 'buddypress' ),
+			'description'       => __( 'Ensure result set includes specific IDs.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -197,7 +197,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -1208,7 +1208,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 				),
 				'starred_message_ids' => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'List of starred message ids.', 'buddypress' ),
+					'description' => __( 'List of starred message IDs.', 'buddypress' ),
 					'readonly'    => true,
 					'type'        => 'array',
 					'items'       => array(

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -57,7 +57,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'The unique numeric ID for the notification.', 'buddypress' ),
+						'description' => __( 'A unique numeric ID for the notification.', 'buddypress' ),
 						'type'        => 'integer',
 					),
 				),
@@ -246,7 +246,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && is_null( $notification->item_id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_notification_invalid_id',
-				__( 'Invalid notification id.', 'buddypress' ),
+				__( 'Invalid notification ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -461,7 +461,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 		if ( ! BP_Notifications_Notification::delete( array( 'id' => $notification->id ) ) ) {
 			return new WP_Error(
 				'bp_rest_notification_invalid_id',
-				__( 'Invalid notification id.', 'buddypress' ),
+				__( 'Invalid notification ID.', 'buddypress' ),
 				array(
 					'status' => 500,
 				)

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -141,7 +141,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		if ( empty( $field->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field id.', 'buddypress' ),
+				__( 'Invalid field ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -152,7 +152,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! bp_rest_get_user( $request['user_id'] ) ) {
 			$retval = new WP_Error(
 				'bp_rest_member_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -200,7 +200,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		if ( empty( $field->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field id.', 'buddypress' ),
+				__( 'Invalid field ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -288,7 +288,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid member id.', 'buddypress' ),
+				__( 'Invalid member ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -333,7 +333,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		if ( empty( $field->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field id.', 'buddypress' ),
+				__( 'Invalid field ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -572,7 +572,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 							'readonly'    => true,
 						),
 						'rendered'     => array(
-							'description' => __( 'HTML value for the field, transformed for display.' ),
+							'description' => __( 'HTML value for the field, transformed for display.', 'buddypress' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -237,7 +237,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 		if ( empty( $field_group->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field group id.', 'buddypress' ),
+				__( 'Invalid field group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -418,7 +418,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 		if ( empty( $field_group->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field group id.', 'buddypress' ),
+				__( 'Invalid field group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -520,7 +520,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 		if ( empty( $field_group->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field group id.', 'buddypress' ),
+				__( 'Invalid field group ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -278,7 +278,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 		if ( empty( $profile_field_id ) || empty( $field->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field id.', 'buddypress' ),
+				__( 'Invalid field ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -528,7 +528,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 		if ( empty( $field->id ) ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid profile field id.', 'buddypress' ),
+				__( 'Invalid profile field ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -707,7 +707,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 		if ( true === $retval && empty( $field->id ) ) {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
-				__( 'Invalid field id.', 'buddypress' ),
+				__( 'Invalid field ID.', 'buddypress' ),
 				array(
 					'status' => 404,
 				)
@@ -1057,7 +1057,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 							'readonly'    => true,
 						),
 						'rendered'     => array(
-							'description' => __( 'HTML value for the field, transformed for display.' ),
+							'description' => __( 'HTML value for the field, transformed for display.', 'buddypress' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,


### PR DESCRIPTION
1. There was 2 missing text domains (`buddypress`).
2. `id` or `ID`.. I chose `ID` everywhere :)
3. I also tried to limit ways of writing the same thing. Eg: not authorized ~ unauthorized or sometimes a full stop was missing.
4. I fixed a misuse of the %1$s placeholder
5. I fixed a translator comment where %$1s was used instead of %s