### PR TITLE
Use the right check for group avatars

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -597,31 +597,36 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'name'               => bp_get_group_name( $item ),
 			'slug'               => bp_get_group_slug( $item ),
 			'status'             => bp_get_group_status( $item ),
-			'avatar_urls'        => array(),
 			'admins'             => array(),
 			'mods'               => array(),
 			'total_member_count' => null,
 			'last_activity'      => null,
 		);
 
-		// Avatars.
-		$data['avatar_urls']['thumb'] = bp_core_fetch_avatar(
-			array(
-				'html'    => false,
-				'object'  => 'group',
-				'item_id' => $item->id,
-				'type'    => 'thumb',
-			)
-		);
+		// Get item schema.
+		$schema = $this->get_item_schema();
 
-		$data['avatar_urls']['full'] = bp_core_fetch_avatar(
-			array(
-				'html'    => false,
-				'object'  => 'group',
-				'item_id' => $item->id,
-				'type'    => 'full',
-			)
-		);
+		// Avatars.
+		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
+			$data['avatar_urls'] = array(
+				'thumb' => bp_core_fetch_avatar(
+					array(
+						'html'    => false,
+						'object'  => 'group',
+						'item_id' => $item->id,
+						'type'    => 'thumb',
+					)
+				),
+				'full'  => bp_core_fetch_avatar(
+					array(
+						'html'    => false,
+						'object'  => 'group',
+						'item_id' => $item->id,
+						'type'    => 'full',
+					)
+				),
+			);
+		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 
@@ -1051,7 +1056,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		);
 
 		// Avatars.
-		if ( true === buddypress()->avatar->show_avatars ) {
+		if ( ! bp_disable_group_avatar_uploads() ) {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -253,6 +253,49 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * @group get_item
+	 * @group avatar
+	 */
+	public function test_get_item_with_avatar() {
+		$u = $this->factory->user->create();
+		$this->bp->set_current_user( $u );
+
+		$group = $this->endpoint->get_group_object( $this->group_id );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$all_data = $response->get_data();
+
+		$this->assertArrayHasKey( 'thumb', $all_data[0]['avatar_urls'] );
+		$this->assertArrayHasKey( 'full', $all_data[0]['avatar_urls'] );
+	}
+
+	/**
+	 * @group get_item
+	 * @group avatar
+	 */
+	public function test_get_item_without_avatar() {
+		$u = $this->factory->user->create();
+		$this->bp->set_current_user( $u );
+
+		$group = $this->endpoint->get_group_object( $this->group_id );
+
+		add_filter( 'bp_disable_group_avatar_uploads', '__return_true' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$all_data = $response->get_data();
+
+		remove_filter( 'bp_disable_group_avatar_uploads', '__return_true' );
+
+		$this->assertArrayNotHasKey( 'avatar_urls', $all_data[0] );
+	}
+
+	/**
 	 * @group render_item
 	 */
 	public function test_render_item() {


### PR DESCRIPTION
The check for group avatars should be `! bp_disable_group_avatar_uploads()` and it should be checked when preparing the response.

**This needs to be merged into Master & 0.1**