### PR TITLE
Improve Avatar & Cover image controllers conditional loading

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -58,11 +58,6 @@ function bp_rest() {
 		$controller = new BP_REST_Members_Endpoint();
 		$controller->register_routes();
 
-		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
-		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php';
-		$controller = new BP_REST_Attachments_Member_Avatar_Endpoint();
-		$controller->register_routes();
-
 		if ( bp_get_signup_allowed() ) {
 			require_once dirname( __FILE__ ) . '/includes/bp-signup/classes/class-bp-rest-signup-endpoint.php';
 			$controller = new BP_REST_Signup_Endpoint();
@@ -94,6 +89,21 @@ function bp_rest() {
 		require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php';
 		$controller = new BP_REST_XProfile_Data_Endpoint();
 		$controller->register_routes();
+
+		$is_xprofile_uploads_enabled = array(
+			'avatar'      => ! bp_disable_avatar_uploads(),
+			'cover_image' => bp_is_active( 'xprofile', 'cover_image' ) && ! bp_disable_cover_image_uploads(),
+		);
+
+		if ( array_filter( $is_xprofile_uploads_enabled ) ) {
+			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
+		}
+
+		if ( true === $is_xprofile_uploads_enabled['avatar'] ) {
+			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php';
+			$controller = new BP_REST_Attachments_Member_Avatar_Endpoint();
+			$controller->register_routes();
+		}
 	}
 
 	if ( bp_is_active( 'groups' ) ) {
@@ -113,13 +123,23 @@ function bp_rest() {
 		$controller = new BP_REST_Group_Membership_Request_Endpoint();
 		$controller->register_routes();
 
-		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
-		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php';
-		$controller = new BP_REST_Attachments_Group_Avatar_Endpoint();
-		$controller->register_routes();
+		$is_group_uploads_enabled = array(
+			'avatar'      => ! bp_disable_group_avatar_uploads(),
+			'cover_image' => bp_is_active( 'groups', 'cover_image' ) && ! bp_disable_group_cover_image_uploads(),
+		);
+
+		if ( array_filter( $is_group_uploads_enabled ) ) {
+			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
+		}
+
+		if ( true === $is_group_uploads_enabled['avatar'] ) {
+			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-group-avatar-endpoint.php';
+			$controller = new BP_REST_Attachments_Group_Avatar_Endpoint();
+			$controller->register_routes();
+		}
 
 		// Support to Group Cover.
-		if ( bp_is_active( 'groups', 'cover_image' ) ) {
+		if ( true === $is_group_uploads_enabled['cover_image'] ) {
 			require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-group-cover-endpoint.php';
 			$controller = new BP_REST_Attachments_Group_Cover_Endpoint();
 			$controller->register_routes();

--- a/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -51,7 +51,7 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 	 */
 	public function __construct() {
 		$this->namespace       = bp_rest_namespace() . '/' . bp_rest_version();
-		$this->rest_base       = 'members';
+		$this->rest_base       = buddypress()->profile->id;
 		$this->avatar_instance = new BP_Attachment_Avatar();
 	}
 

--- a/tests/attachments/test-member-avatar-controller.php
+++ b/tests/attachments/test-member-avatar-controller.php
@@ -14,7 +14,7 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		$this->bp_factory   = new BP_UnitTest_Factory();
 		$this->endpoint     = new BP_REST_Attachments_Member_Avatar_Endpoint();
 		$this->bp           = new BP_UnitTestCase();
-		$this->endpoint_url = '/' . bp_rest_namespace() . '/' . bp_rest_version() . '/members/';
+		$this->endpoint_url = '/' . bp_rest_namespace() . '/' . bp_rest_version() . '/xprofile/';
 
 		$this->user_id = $this->bp_factory->user->create( array(
 			'role' => 'administrator',


### PR DESCRIPTION
1. The User Avatar is attached to the xProfile component (not the Members one)
2. Only load Avatar/Cover image uploads if local uploads are enabled for both objects
3. The cover image needs an additional check because some theme might deactivate it removing their support to it (it is the purpose of bp_is_active( group, cover_image )).

PS: as this part is handled within Components class into BuddyPress Core, there is no need to backport the commit on branch 0.1 imho.