### PR TITLE
Load the Member Avatar Controller if the xProfile component is active

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -58,11 +58,6 @@ function bp_rest() {
 		$controller = new BP_REST_Members_Endpoint();
 		$controller->register_routes();
 
-		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
-		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php';
-		$controller = new BP_REST_Attachments_Member_Avatar_Endpoint();
-		$controller->register_routes();
-
 		if ( bp_get_signup_allowed() ) {
 			require_once dirname( __FILE__ ) . '/includes/bp-signup/classes/class-bp-rest-signup-endpoint.php';
 			$controller = new BP_REST_Signup_Endpoint();
@@ -93,6 +88,11 @@ function bp_rest() {
 
 		require_once dirname( __FILE__ ) . '/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php';
 		$controller = new BP_REST_XProfile_Data_Endpoint();
+		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/trait-attachments.php';
+		require_once dirname( __FILE__ ) . '/includes/bp-attachments/classes/class-bp-rest-attachments-member-avatar-endpoint.php';
+		$controller = new BP_REST_Attachments_Member_Avatar_Endpoint();
 		$controller->register_routes();
 	}
 


### PR DESCRIPTION
As discussed during October 30 dev-chat: until the Member Avatar dependency to xProfile is removed in BuddyPress Core, we will make sure to load the Member Avatar Controller only if the xProfile component is active.

Documentation about this fact has been updated, see [Member Avatar chapter](https://developer.buddypress.org/bp-rest-api/reference/attachments/member-avatar/).

Fixes #249