### PR TITLE
Fix 2 issues about the `edit` context for the Groups controller get_items() method

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -178,6 +178,11 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// Users need (at least, should we be more restrictive ?) to be logged in to use the edit context.
+		if ( 'edit' === $request->get_param( 'context' ) && ! is_user_logged_in() ) {
+			$request->set_param( 'context', 'view' );
+		}
+
 		/**
 		 * Filter the groups `get_items` permissions check.
 		 *
@@ -647,6 +652,20 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 
 			foreach ( (array) $admin_mods['members'] as $user ) {
+				// Make sure to unset private data.
+				$private_keys = array_intersect(
+					array_keys( get_object_vars( $user ) ),
+					array(
+						'user_pass',
+						'user_email',
+						'user_activation_key',
+					)
+				);
+
+				foreach ( $private_keys as $private_key ) {
+					unset( $user->{$private_key} );
+				}
+
 				if ( ! empty( $user->is_admin ) ) {
 					$data['admins'][] = $user;
 				} else {

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -133,6 +133,11 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		// Actually, query it.
 		$groups = groups_get_groups( $args );
 
+		// Users need (at least, should we be more restrictive ?) to be logged in to use the edit context.
+		if ( 'edit' === $request->get_param( 'context' ) && ! is_user_logged_in() ) {
+			$request->set_param( 'context', 'view' );
+		}
+
 		$retval = array();
 		foreach ( $groups['groups'] as $group ) {
 			$retval[] = $this->prepare_response_for_collection(
@@ -176,11 +181,6 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 					'status' => rest_authorization_required_code(),
 				)
 			);
-		}
-
-		// Users need (at least, should we be more restrictive ?) to be logged in to use the edit context.
-		if ( 'edit' === $request->get_param( 'context' ) && ! is_user_logged_in() ) {
-			$request->set_param( 'context', 'view' );
 		}
 
 		/**

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -124,7 +124,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 			}
 		}
 
-		$this->assertEmpty( $admins, 'Listing Admins should not be possible for regular users' );
+		$this->assertEmpty( $admins, 'Listing Admins should not be possible for unauthenticated users' );
 	}
 
 	/**

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -103,6 +103,59 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * @group get_items
+	 */
+	public function test_get_items_edit_context() {
+		$a1 = $this->bp_factory->group->create();
+		$a2 = $this->bp_factory->group->create();
+		$a3 = $this->bp_factory->group->create();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$admins = array();
+		$groups = $response->get_data();
+		foreach ( $groups as $group ) {
+			if ( isset( $group['admins'] ) ) {
+				$admins = array_merge( $admins, $group['admins'] );
+			}
+		}
+
+		$this->assertEmpty( $admins, 'Listing Admins should not be possible for regular users' );
+	}
+
+	/**
+	 * @group get_items
+	 */
+	public function test_get_items_edit_context_users_private_data() {
+		$this->bp->set_current_user( $this->user );
+
+		$a1 = $this->bp_factory->group->create();
+		$a2 = $this->bp_factory->group->create();
+		$a3 = $this->bp_factory->group->create();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$has_private_datas = false;
+		$admins = wp_list_pluck( $response->get_data(), 'admins' );
+
+		foreach ( $admins as $admin ) {
+			if ( isset( $admin['user_pass'] ) || isset( $admin['user_email'] ) || isset( $admin['user_activation_key'] ) ) {
+				$has_private_datas = true;
+			}
+		}
+
+		$this->assertFalse( $has_private_datas, 'Listing private data should not be possible for any user' );
+	}
+
+	/**
 	 * @group get_item
 	 */
 	public function test_get_item() {


### PR DESCRIPTION
1) Regular users should not be able to use the `edit` context.
2) Some user data should be unset like the user_pass or the user_email when building the list of mods/admins/members inside the `edit` context.

**Important**:  we'll need to backport the fix on [branch 0.1](https://github.com/buddypress/BP-REST/tree/0.1)