### PR TITLE
Improve translators comments

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1406,7 +1406,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 
 			$avatar_properties['full'] = array(
 				'context'     => array( 'view', 'edit' ),
-				/* translators: Full image size for the member Avatar */
+				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
@@ -1414,8 +1414,8 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 
 			$avatar_properties['thumb'] = array(
 				'context'     => array( 'view', 'edit' ),
-				/* translators: Thumb imaze size for the member Avatar */
-				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
+				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
+				'description' => sprintf( _( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
 			);

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1415,7 +1415,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			$avatar_properties['thumb'] = array(
 				'context'     => array( 'view', 'edit' ),
 				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
-				'description' => sprintf( _( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
+				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
 			);

--- a/includes/bp-attachments/classes/trait-attachments.php
+++ b/includes/bp-attachments/classes/trait-attachments.php
@@ -46,7 +46,7 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_cover_upload_error",
 				sprintf(
-					/* translators: Error message. */
+					/* translators: %s: the upload error message */
 					__( 'Upload Failed! Error was: %s', 'buddypress' ),
 					$uploaded_image['error']
 				),
@@ -171,7 +171,7 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_avatar_upload_error",
 				sprintf(
-					/* translators: %s is replaced with the error */
+					/* translators: %s: the upload error message */
 					__( 'Upload failed! Error was: %s.', 'buddypress' ),
 					$avatar_original['error']
 				),
@@ -274,7 +274,7 @@ trait BP_REST_Attachments {
 			return new WP_Error(
 				"bp_rest_attachments_{$this->object}_avatar_upload_error",
 				sprintf(
-					/* translators: %s is replaced with error message. */
+					/* translators: %s: the upload error message */
 					__( 'Upload failed! Error was: %s', 'buddypress' ),
 					$img_dir->get_error_message()
 				),

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -456,7 +456,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(
-				/* translators: Full image size for the group Avatar */
+				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
@@ -464,7 +464,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			);
 
 			$avatar_properties['thumb'] = array(
-				/* translators: Thumb imaze size for the group Avatar */
+				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1122,7 +1122,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(
-				/* translators: Full image size for the group Avatar */
+				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
@@ -1130,7 +1130,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 
 			$avatar_properties['thumb'] = array(
-				/* translators: Thumb imaze size for the group Avatar */
+				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -737,7 +737,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(
-				/* translators: Full image size for the member Avatar */
+				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
@@ -745,7 +745,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			);
 
 			$avatar_properties['thumb'] = array(
-				/* translators: Thumb imaze size for the member Avatar */
+				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
 				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',


### PR DESCRIPTION
Now we are using WP CLI to generate the BuddyPress pot file, we need to have consistent translators comments for i18n strings. The comment changes are making sure we are using the same in BuddyPress or into the BP REST API considering the same strings. It also fixes WP CLI warnings when releasing BuddyPress.

See [#8260](https://buddypress.trac.wordpress.org/ticket/8260) for more info.