### PR TITLE
Update Blogs component unit test to BP Trunk latest changes

### DIFF
--- a/tests/attachments/test-blog-avatar-controller.php
+++ b/tests/attachments/test-blog-avatar-controller.php
@@ -123,10 +123,6 @@ class BP_Test_REST_Attachments_Blog_Avatar_Endpoint extends WP_Test_REST_Control
 			$this->markTestSkipped();
 		}
 
-		if ( function_exists( 'wp_initialize_site' ) ) {
-			$this->setExpectedDeprecated( 'wpmu_new_blog' );
-		}
-
 		$blog_id = $this->bp_factory->blog->create();
 
 		// Single.
@@ -143,10 +139,6 @@ class BP_Test_REST_Attachments_Blog_Avatar_Endpoint extends WP_Test_REST_Control
 	public function test_context_param() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped();
-		}
-
-		if ( function_exists( 'wp_initialize_site' ) ) {
-			$this->setExpectedDeprecated( 'wpmu_new_blog' );
 		}
 
 		$blog_id = $this->bp_factory->blog->create();

--- a/tests/blogs/test-controller.php
+++ b/tests/blogs/test-controller.php
@@ -49,10 +49,6 @@ class BP_Test_REST_Blogs_Endpoint extends WP_Test_REST_Controller_Testcase {
 			$this->markTestSkipped();
 		}
 
-		if ( function_exists( 'wp_initialize_site' ) ) {
-			$this->setExpectedDeprecated( 'wpmu_new_blog' );
-		}
-
 		$u = $this->bp_factory->user->create();
 		$this->bp->set_current_user( $u );
 
@@ -80,10 +76,6 @@ class BP_Test_REST_Blogs_Endpoint extends WP_Test_REST_Controller_Testcase {
 	public function test_get_item() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped();
-		}
-
-		if ( function_exists( 'wp_initialize_site' ) ) {
-			$this->setExpectedDeprecated( 'wpmu_new_blog' );
 		}
 
 		$blog = $this->bp_factory->blog->create(
@@ -191,10 +183,6 @@ class BP_Test_REST_Blogs_Endpoint extends WP_Test_REST_Controller_Testcase {
 	public function test_get_additional_fields() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped();
-		}
-
-		if ( function_exists( 'wp_initialize_site' ) ) {
-			$this->setExpectedDeprecated( 'wpmu_new_blog' );
 		}
 
 		$registered_fields = $GLOBALS['wp_rest_additional_fields'];


### PR DESCRIPTION
BuddyPress trunk is no more using 5.1 deprecated hooks for the Blogs component. We do not need anymore to expect some deprecation into BP REST unit tests.