### PR TITLE
Stop forcing the context parameter of the request

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -798,9 +798,6 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		// Setting context.
-		$request->set_param( 'context', 'edit' );
-
 		// Prepare the response now the user favorites has been updated.
 		$retval = array(
 			$this->prepare_response_for_collection(

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -526,9 +526,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function update_starred( $request ) {
-		// Setting context.
-		$request->set_param( 'context', 'edit' );
-
 		$message = $this->get_message_object( $request['id'] );
 
 		if ( empty( $message->id ) ) {


### PR DESCRIPTION
Since [WP47559](https://core.trac.wordpress.org/changeset/47559/) forcing this parameter generates failing tests.

I do not think we need to do this.

Could you have a look at it @renatonascalves ?