### PR TITLE
Make sure only the Group Admin can delete others membership

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -633,7 +633,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 			$loggedin_user_id = bp_loggedin_user_id();
 
 			if ( $user->ID !== $loggedin_user_id ) {
-				if ( true === $retval && ! groups_is_user_admin( $loggedin_user_id, $group->id ) && ! groups_is_user_mod( $loggedin_user_id, $group->id ) ) {
+				if ( true === $retval && ! groups_is_user_admin( $loggedin_user_id, $group->id ) ) {
 					$retval = new WP_Error(
 						'bp_rest_authorization_required',
 						__( 'Sorry, you need to be logged in to view a group membership.', 'buddypress' ),


### PR DESCRIPTION
#299 is fixing the failing tests here.

I've checked, `groups_remove_member()` returns false if `!  bp_is_item_admin()`. `bp_is_item_admin()` is not containing mods but only admins, see [src/bp-groups/classes/class-bp-groups-component.php#L311](https://github.com/buddypress/BuddyPress/blob/master/src/bp-groups/classes/class-bp-groups-component.php#L311)