### PR TITLE
Make sure to use the right number/offset collection params for signups

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
@@ -127,8 +127,8 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 			'order'      => $request['order'],
 			'orderby'    => $request['orderby'],
 			'user_login' => $request['user_login'],
-			'page'       => $request['number'],
-			'offset'     => $request['per_page'],
+			'number'     => $request['number'],
+			'offset'     => $request['offset'],
 		);
 
 		if ( empty( $request['include'] ) ) {
@@ -156,7 +156,7 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $retval );
-		$response = bp_rest_response_add_total_headers( $response, $signups['total'], $args['offset'] );
+		$response = bp_rest_response_add_total_headers( $response, $signups['total'], $args['number'] );
 
 		/**
 		 * Fires after a list of signups is fetched via the REST API.
@@ -762,7 +762,23 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 		$params                       = parent::get_collection_params();
 		$params['context']['default'] = 'view';
 
-		unset( $params['page'], $params['search'] );
+		unset( $params['page'], $params['per_page'], $params['search'] );
+
+		$params['number'] = array(
+			'description'       => __( 'Total number of signups to return.', 'buddypress' ),
+			'default'           => 1,
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['offset'] = array(
+			'description'       => __( 'Offset the result set by a specific number of items.', 'buddypress' ),
+			'default'           => 0,
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 
 		$params['include'] = array(
 			'description'       => __( 'Ensure result set includes specific IDs.', 'buddypress' ),
@@ -779,14 +795,6 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 			'type'              => 'string',
 			'enum'              => array( 'asc', 'desc' ),
 			'sanitize_callback' => 'sanitize_key',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['number'] = array(
-			'description'       => __( 'Total number of signups to return.', 'buddypress' ),
-			'default'           => 1,
-			'type'              => 'integer',
-			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/tests/signup/test-controller.php
+++ b/tests/signup/test-controller.php
@@ -104,13 +104,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$s3 = $this->create_signup();
 		$s4 = $this->create_signup();
 
-		$signup = $this->endpoint->get_signup_object( $s1 );
-
 		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
 		$request->set_query_params(
 			array(
-				'per_page' => 2,
-				'include'  => array( $s1, $s2, $s3, $s4 ),
+				'include' => array( $s1, $s2, $s3, $s4 ),
+				'number'  => 2,
 			)
 		);
 
@@ -120,6 +118,7 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$headers = $response->get_headers();
+
 		$this->assertEquals( 4, $headers['X-WP-Total'] );
 		$this->assertEquals( 2, $headers['X-WP-TotalPages'] );
 	}


### PR DESCRIPTION
While I was working on #301 I've found this issue.

`per_page` is not the offset, it is the `number`. To avoid confusions I think we should use `number` & `offset` parameters  for signups.

Let's fix it before 6.0.0-RC1 [April 29](https://wordpress.slack.com/archives/C02RQBYUG/p1587584053231800) ;)