### PR TITLE
Improve blog avatar into the Blogs endpoints

### DIFF
--- a/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
@@ -27,6 +27,16 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 	protected $blogs_endpoint;
 
 	/**
+	 * This variable is used to query for the requested blog only once.
+	 * It is set during the permission check methods.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var BP_Blogs_Blog
+	 */
+	protected $blog;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 6.0.0
@@ -73,23 +83,17 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
-
-		// Check if user exists and it is valid.
-		$admin_user_admin = $request['user_id'];
-		if ( 0 !== $admin_user_admin ) {
-			$user = get_user_by( 'id', $admin_user_admin );
-			if ( ! $user instanceof WP_User ) {
-				return new WP_Error(
-					'bp_rest_blog_avatar_get_item_user_failed',
-					__( 'There was a problem confirming if user is valid.', 'buddypress' ),
-					array(
-						'status' => 500,
-					)
-				);
-			}
-
-			$admin_user_admin = $user->ID;
+		if ( empty( $this->blog->admin_user_id ) ) {
+			return new WP_Error(
+				'bp_rest_blog_avatar_get_item_user_failed',
+				__( 'There was a problem confirming the blog\'s user admin is valid.', 'buddypress' ),
+				array(
+					'status' => 500,
+				)
+			);
 		}
+
+		$admin_user_admin = (int) $this->blog->admin_user_id;
 
 		$args = array();
 		foreach ( array( 'full', 'thumb' ) as $type ) {
@@ -148,10 +152,10 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function get_item_permissions_check( $request ) {
-		$retval = true;
-		$blog   = $this->blogs_endpoint->get_blog_object( $request['id'] );
+		$retval     = true;
+		$this->blog = $this->blogs_endpoint->get_blog_object( $request['id'] );
 
-		if ( true === $retval && ! is_object( $blog ) ) {
+		if ( true === $retval && ! is_object( $this->blog ) ) {
 			$retval = new WP_Error(
 				'bp_rest_blog_invalid_id',
 				__( 'Invalid group ID.', 'buddypress' ),
@@ -271,14 +275,6 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 			'default'           => '',
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['user_id'] = array(
-			'description'       => __( 'The Blog admin user ID to avatar fallback.', 'buddypress' ),
-			'default'           => 0,
-			'type'              => 'integer',
-			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
@@ -102,8 +102,9 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 					'type'          => $type,
 					'blog_id'       => $request['id'],
 					'admin_user_id' => $admin_user_admin,
+					'html'          => (bool) $request['html'],
 					'alt'           => $request['alt'],
-					'no_grav'       => (bool) $request['no_grav'],
+					'no_grav'       => (bool) $request['no_user_gravatar'],
 				)
 			);
 		}
@@ -270,6 +271,14 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 		// Removing unused params.
 		unset( $params['search'], $params['page'], $params['per_page'] );
 
+		$params['html'] = array(
+			'description'       => __( 'Whether to return an <img> HTML element, vs a raw URL to an avatar.', 'buddypress' ),
+			'default'           => false,
+			'type'              => 'boolean',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
 		$params['alt'] = array(
 			'description'       => __( 'The alt attribute for the <img> element.', 'buddypress' ),
 			'default'           => '',
@@ -278,8 +287,8 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$params['no_grav'] = array(
-			'description'       => __( 'Whether to disable the default Gravatar fallback.', 'buddypress' ),
+		$params['no_user_gravatar'] = array(
+			'description'       => __( 'Whether to disable the default Gravatar Admin user fallback.', 'buddypress' ),
 			'default'           => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -452,7 +452,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 		);
 
 		// Blog Avatars.
-		if ( ! buddypress()->avatar->show_avatars ) {
+		if ( buddypress()->avatar->show_avatars ) {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(

--- a/tests/blogs/test-controller.php
+++ b/tests/blogs/test-controller.php
@@ -153,7 +153,7 @@ class BP_Test_REST_Blogs_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 8, count( $properties ) );
+		$this->assertEquals( 9, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'user_id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );


### PR DESCRIPTION
1. The `BP_REST_Blogs_Endpoint` controller was never fetching avatars because the condition to add the `avatar_urls` property to the schema is the opposite of what it should be. Instead of `! buddypress()->avatar->show_avatars` it musts be `buddypress()->avatar->show_avatars`.

2. I've improved the `BP_REST_Attachments_Blog_Avatar_Endpoint` controller so that:
- There is no need anymore to include a `user_id` argument to get the fallback admin avatar. It seemed weird to me it was more difficult to get the blog avatar from this controller than from the `BP_REST_Blogs_Endpoint` one. To do so I'm simply "catching" the Blog object during the permission check to avoid requerying.
- I've added the `html` property to the collection params to improve consistency with the other avatar endpoints. I know it wasn't available in BuddyPress, but I will commit [#8286](https://buddypress.trac.wordpress.org/ticket/8286) asap to fix this.

I've created the documentation page for the Blog Avatar endpoint accordingly to these improvements, see: https://developer.buddypress.org/bp-rest-api/reference/attachments/blog-avatar/