### PR TITLE
Member Avatar: Rename the `no_grav` to `no_gravatar`

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -495,7 +495,7 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$params['no_grav'] = array(
+		$params['no_gravatar'] = array(
 			'description'       => __( 'Whether to disable the default Gravatar fallback.', 'buddypress' ),
 			'default'           => false,
 			'type'              => 'boolean',


### PR DESCRIPTION
As the `get_item()` method is using `$request['no_gravatar']` to set the `no_grav` argument of the function to fetch the user avatar, the collection param must be `no_gravatar` so that it is taken in account during GET requests.

I've updated the documentation page: https://developer.buddypress.org/bp-rest-api/reference/attachments/member-avatar/