### PR TITLE
Group and Members Cover image

### DIFF
--- a/includes/bp-attachments/classes/trait-attachments.php
+++ b/includes/bp-attachments/classes/trait-attachments.php
@@ -30,6 +30,7 @@ trait BP_REST_Attachments {
 		switch ( $this->object ) {
 			case 'group':
 				$bp->groups->current_group = $this->group;
+				$bp->current_component     = 'groups';
 				break;
 			case 'user':
 			default:
@@ -131,7 +132,7 @@ trait BP_REST_Attachments {
 		}
 
 		return sprintf(
-			'%1$/%2$/%3$',
+			'%1$s/%2$s/%3$s',
 			$bp_attachments_uploads_dir['baseurl'],
 			$cover_subdir,
 			$cover['cover_basename']

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
@@ -407,7 +407,7 @@ class BP_REST_Attachments_Member_Cover_Endpoint extends WP_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_attachments_user_cover',
+			'title'      => 'bp_attachments_member_cover',
 			'type'       => 'object',
 			'properties' => array(
 				'image' => array(


### PR DESCRIPTION
- Make sure the cover image is fetched once uploaded. So far it's an empty image.
- Make sure the Groups component is the current one when uploading a Group Cover image otherwise the file is uploaded into the current members's cover image directory.

The documentation for these endpoints has been created, see #301 