### PR TITLE
Group Membership Endpoint: search_terms should default to false

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -138,6 +138,10 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 			$args['exclude'] = false;
 		}
 
+		if ( is_null( $args['search_terms'] ) ) {
+			$args['search_terms'] = false;
+		}
+
 		/**
 		 * Filter the query arguments for the request.
 		 *


### PR DESCRIPTION
See https://buddypress.trac.wordpress.org/ticket/8299

In short using `NULL` as the default value can generate SQL overheat unnecessarily.

BTW we should probably create a 0.2 branch in case some new features need to be added to the plugin.

This way this 0.2 branch would be used by the BuddyPress 6.0 branch.