### PR TITLE
Bump plugin version to 0.3.0

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -5,7 +5,7 @@
  * Description: BuddyPress extension for WordPress' JSON-based REST API.
  * Author: The BuddyPress Community
  * Author URI: https://buddypress.org/
- * Version: 0.2.0
+ * Version: 0.3.0
  * Text Domain: buddypress
  * Requires at least: 4.8
  * Tested up to: 5.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "bp-rest",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bp-rest",
   "title": "BP-REST",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Access your BuddyPress site's data through an easy-to-use HTTP REST API.",
   "devDependencies": {
     "grunt": "^1.1.0",


### PR DESCRIPTION
I’ve just created [branch 0.2](https://github.com/buddypress/BP-REST/tree/0.2). It corresponds to the BuddyPress 6.0 branch (see [12658](https://buddypress.trac.wordpress.org/changeset/12658)). To work on new features, I think it is safer to bump plugin version to 0.3.0