### PR TITLE
Allow Group details to be available in its single endpoint

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -272,16 +272,6 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		if ( true === $retval && ! $this->can_see( $group ) ) {
-			$retval = new WP_Error(
-				'bp_rest_authorization_required',
-				__( 'Sorry, you cannot view the group.', 'buddypress' ),
-				array(
-					'status' => rest_authorization_required_code(),
-				)
-			);
-		}
-
 		/**
 		 * Filter the groups `get_item` permissions check.
 		 *
@@ -966,34 +956,6 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Can a user see a group?
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param  BP_Groups_Group $group Group object.
-	 * @return bool
-	 */
-	protected function can_see( $group ) {
-
-		// If it is not a hidden/private group, user can see it.
-		if ( 'public' === $group->status ) {
-			return true;
-		}
-
-		// Moderators.
-		if ( bp_current_user_can( 'bp_moderate' ) ) {
-			return true;
-		}
-
-		// User is a member of the group.
-		if ( groups_is_user_member( bp_loggedin_user_id(), $group->id ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * See if user can delete or update a group.
 	 *
 	 * @since 0.1.0
@@ -1020,11 +982,11 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				return true;
 			}
 
-			if ( is_user_logged_in() && isset( $request['user_id'] ) && absint( $request['user_id'] ) === bp_loggedin_user_id() ) {
-				return true;
-			}
-
-			return false;
+			return (
+				is_user_logged_in()
+				&& isset( $request['user_id'] )
+				&& absint( $request['user_id'] ) === bp_loggedin_user_id()
+			);
 		}
 
 		return true;

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -272,6 +272,16 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		if ( true === $retval && ! $this->can_see( $group ) ) {
+			$retval = new WP_Error(
+				'bp_rest_authorization_required',
+				__( 'Sorry, you cannot view the group.', 'buddypress' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
 		/**
 		 * Filter the groups `get_item` permissions check.
 		 *
@@ -965,6 +975,25 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	 */
 	protected function can_user_delete_or_update( $group ) {
 		return ( bp_current_user_can( 'bp_moderate' ) || bp_loggedin_user_id() === $group->creator_id );
+	}
+
+	/**
+	 * Can a user see a group?
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param  BP_Groups_Group $group Group object.
+	 * @return bool
+	 */
+	protected function can_see( $group ) {
+
+		// If it is not a hidden group, user can see it.
+		if ( 'hidden' !== $group->status ) {
+			return true;
+		}
+
+		// Check for moderators or if user is a member of the group.
+		return ( bp_current_user_can( 'bp_moderate' ) || groups_is_user_member( bp_loggedin_user_id(), $group->id ) );
 	}
 
 	/**

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -179,6 +179,24 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_unauthenticated() {
+		$group = $this->endpoint->get_group_object( $this->group_id );
+		$this->assertEquals( $this->group_id, $group->id );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$all_data = $response->get_data();
+
+		$this->check_group_data( $group, $all_data[0], 'view', $response->get_links() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_invalid_group_id() {
 		$this->bp->set_current_user( $this->user );
 
@@ -186,123 +204,6 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_group_invalid_id', $response, 404 );
-	}
-
-	/**
-	 * @group get_item
-	 */
-	public function test_get_hidden_group() {
-		$u = $this->factory->user->create();
-		$g = $this->bp_factory->group->create( array(
-			'status' => 'hidden',
-		) );
-
-		$group = $this->endpoint->get_group_object( $g );
-
-		$this->bp->add_user_to_group( $u, $group->id );
-
-		$this->bp->set_current_user( $u );
-
-		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
-		$request->set_param( 'context', 'view' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-
-		$all_data = $response->get_data();
-
-		$this->check_group_data( $group, $all_data[0], 'view', $response->get_links() );
-	}
-
-	/**
-	 * @group get_item
-	 */
-	public function test_get_private_group() {
-		$u = $this->factory->user->create();
-		$g = $this->bp_factory->group->create( array(
-			'status' => 'private',
-		) );
-
-		$group = $this->endpoint->get_group_object( $g );
-
-		$this->bp->add_user_to_group( $u, $group->id );
-
-		$this->bp->set_current_user( $u );
-
-		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
-		$request->set_param( 'context', 'view' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-
-		$all_data = $response->get_data();
-
-		$this->check_group_data( $group, $all_data[0], 'view', $response->get_links() );
-	}
-
-	/**
-	 * @group get_item
-	 */
-	public function test_get_hidden_group_without_being_from_group() {
-		$u = $this->factory->user->create();
-		$g = $this->bp_factory->group->create( array(
-			'status' => 'hidden',
-		) );
-
-		$group = $this->endpoint->get_group_object( $g );
-
-		$this->bp->set_current_user( $u );
-
-		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
-		$request->set_param( 'context', 'view' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
-	}
-
-	/**
-	 * @group get_item
-	 */
-	public function test_get_private_group_without_being_from_group() {
-		$u = $this->factory->user->create();
-		$g = $this->bp_factory->group->create( array(
-			'status' => 'private',
-		) );
-
-		$group = $this->endpoint->get_group_object( $g );
-		$this->assertEquals( $g, $group->id );
-
-		$this->bp->set_current_user( $u );
-
-		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
-		$request->set_param( 'context', 'view' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
-	}
-
-	/**
-	 * @group get_item
-	 */
-	public function test_get_private_group_mods() {
-		$g = $this->bp_factory->group->create( array(
-			'status' => 'private',
-		) );
-
-		$group = $this->endpoint->get_group_object( $g );
-		$this->assertEquals( $g, $group->id );
-
-		$this->bp->set_current_user( $this->user );
-
-		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
-		$request->set_param( 'context', 'view' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-
-		$all_data = $response->get_data();
-
-		$this->check_group_data( $group, $all_data[0], 'view', $response->get_links() );
 	}
 
 	/**


### PR DESCRIPTION
The information from the `buddypress/v1/groups/group_id` endpoint is already available in the `get_items` endpoint from this component. So there is no need to hide it from public view.

Also, with this change, a few unit tests became redudant, so they were removed.

closes #314 