### PR TITLE
List hidden groups if user has permissions, otherwise return public and private groups

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -144,7 +144,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		}
 
 		// See if the user can see hidden groups.
-		if ( isset( $request['show_hidden'] ) && true === (bool) $request['show_hidden']  && ! $this->can_see_hidden_groups( $request ) ) {
+		if ( isset( $request['show_hidden'] ) && true === (bool) $request['show_hidden'] && ! $this->can_see_hidden_groups( $request ) ) {
 			$args['show_hidden'] = false;
 		}
 

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1010,15 +1010,15 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	 * @return bool
 	 */
 	protected function can_see_hidden_groups( $request ) {
-			if ( bp_current_user_can( 'bp_moderate' ) ) {
-				return true;
-			}
+		if ( bp_current_user_can( 'bp_moderate' ) ) {
+			return true;
+		}
 
-			return (
-				is_user_logged_in()
-				&& isset( $request['user_id'] )
-				&& absint( $request['user_id'] ) === bp_loggedin_user_id()
-			);
+		return (
+			is_user_logged_in()
+			&& isset( $request['user_id'] )
+			&& absint( $request['user_id'] ) === bp_loggedin_user_id()
+		);
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -143,6 +143,10 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			$args['parent_id'] = null;
 		}
 
+		if ( isset( $request['show_hidden'] ) && ! $this->can_see_hidden_groups( $request ) ) {
+			$args['show_hidden'] = false;
+		}
+
 		/**
 		 * Filter the query arguments for the request.
 		 *
@@ -195,16 +199,6 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		$retval = true;
-
-		if ( ! $this->can_see_hidden_groups( $request ) ) {
-			$retval = new WP_Error(
-				'bp_rest_authorization_required',
-				__( 'Sorry, you cannot view hidden groups.', 'buddypress' ),
-				array(
-					'status' => rest_authorization_required_code(),
-				)
-			);
-		}
 
 		/**
 		 * Filter the groups `get_items` permissions check.
@@ -1014,20 +1008,11 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	 * @return bool
 	 */
 	protected function can_see_hidden_groups( $request ) {
-		if ( $request['show_hidden'] ) {
-
-			if ( bp_current_user_can( 'bp_moderate' ) ) {
-				return true;
-			}
-
-			if ( is_user_logged_in() && isset( $request['user_id'] ) && absint( $request['user_id'] ) === bp_loggedin_user_id() ) {
-				return true;
-			}
-
-			return false;
+		if ( bp_current_user_can( 'bp_moderate' ) ) {
+			return true;
 		}
 
-		return true;
+		return ( is_user_logged_in() && isset( $request['user_id'] ) && absint( $request['user_id'] ) === bp_loggedin_user_id() );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -143,7 +143,8 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			$args['parent_id'] = null;
 		}
 
-		if ( isset( $request['show_hidden'] ) && ! $this->can_see_hidden_groups( $request ) ) {
+		// See if the user can see hidden groups.
+		if ( isset( $request['show_hidden'] ) && true === (bool) $request['show_hidden']  && ! $this->can_see_hidden_groups( $request ) ) {
 			$args['show_hidden'] = false;
 		}
 


### PR DESCRIPTION
I'm suggesting a change in how we check for the permissions when trying to list groups. Right now, if a person tries to list hidden groups but have no permission to do so, we return an error object. That seems too much.

I'm suggesting we don't show an error object but instead return the public and private groups. Users with permissions to see the groups, will continue to do so if they choose it, of course.