### PR TITLE
Update/remove/append group types

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -910,12 +910,12 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 
 		// Update group type(s).
 		if ( isset( $prepared_group->group_id ) && isset( $request['types'] ) ) {
+			bp_groups_set_group_type( $prepared_group->group_id, $request['types'], false );
+		}
 
-			// Append on update. Add on creation.
-			$append = WP_REST_Server::EDITABLE === $request->get_method();
-
-			// Add/Append group type(s).
-			bp_groups_set_group_type( $prepared_group->group_id, $request['types'], $append );
+		// Append group type(s).
+		if ( isset( $prepared_group->group_id ) && isset( $request['append_types'] ) ) {
+			bp_groups_set_group_type( $prepared_group->group_id, $request['append_types'], true );
 		}
 
 		/**
@@ -1087,6 +1087,18 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			if ( WP_REST_Server::EDITABLE === $method ) {
 				$key = 'update_item';
 				unset( $args['slug'] );
+
+				// Append group types.
+				$args['append_types'] = array(
+					'description'       => __( 'Append type(s) for a group.', 'buddypress' ),
+					'type'              => 'array',
+					'enum'              => bp_groups_get_group_types(),
+					'sanitize_callback' => 'bp_rest_sanitize_group_types',
+					'validate_callback' => 'bp_rest_validate_group_types',
+					'items'             => array(
+						'type' => 'string',
+					),
+				);
 			}
 		} elseif ( WP_REST_Server::DELETABLE === $method ) {
 			$key = 'delete_item';

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -913,6 +913,16 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			bp_groups_set_group_type( $prepared_group->group_id, $request['types'], false );
 		}
 
+		// Remove group type(s).
+		if ( isset( $prepared_group->group_id ) && isset( $request['remove_types'] ) ) {
+			array_map(
+				function( $type ) use ( $prepared_group ) {
+					bp_groups_remove_group_type( $prepared_group->group_id, $type );
+				},
+				$request['remove_types']
+			);
+		}
+
 		// Append group type(s).
 		if ( isset( $prepared_group->group_id ) && isset( $request['append_types'] ) ) {
 			bp_groups_set_group_type( $prepared_group->group_id, $request['append_types'], true );
@@ -1091,6 +1101,18 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				// Append group types.
 				$args['append_types'] = array(
 					'description'       => __( 'Append type(s) for a group.', 'buddypress' ),
+					'type'              => 'array',
+					'enum'              => bp_groups_get_group_types(),
+					'sanitize_callback' => 'bp_rest_sanitize_group_types',
+					'validate_callback' => 'bp_rest_validate_group_types',
+					'items'             => array(
+						'type' => 'string',
+					),
+				);
+
+				// Remove group types.
+				$args['remove_types'] = array(
+					'description'       => __( 'Remove type(s) for a group.', 'buddypress' ),
 					'type'              => 'array',
 					'enum'              => bp_groups_get_group_types(),
 					'sanitize_callback' => 'bp_rest_sanitize_group_types',

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -523,6 +523,27 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group update_item
 	 */
+	public function test_remove_group_type() {
+		bp_groups_register_group_type( 'bar' );
+
+		bp_groups_set_group_type( $this->group_id, 'bar' );
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $this->group_id ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_group_data( array( 'remove_types' => 'bar' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_data()[0]['types'], array() );
+	}
+
+	/**
+	 * @group update_item
+	 */
 	public function test_append_group_type() {
 		bp_groups_register_group_type( 'foo' );
 		bp_groups_register_group_type( 'bar' );

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -523,6 +523,28 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group update_item
 	 */
+	public function test_append_group_type() {
+		bp_groups_register_group_type( 'foo' );
+		bp_groups_register_group_type( 'bar' );
+
+		bp_groups_set_group_type( $this->group_id, 'bar' );
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $this->group_id ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_group_data( array( 'append_types' => 'foo' ) );
+		$request->set_body( wp_json_encode( $params ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_data()[0]['types'], array( 'bar', 'foo' ) );
+	}
+
+	/**
+	 * @group update_item
+	 */
 	public function test_update_item_invalid_id() {
 		$this->bp->set_current_user( $this->user );
 


### PR DESCRIPTION
This takes care of adding, removing and updating group types via three parameters: `remove_types`, `append_types` and `types.`

fixes #320 