### PR TITLE
Make sure the response of activity posted in a group is the activity

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -421,7 +421,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			array(
 				'in'               => $activity_id,
 				'display_comments' => 'stream',
-				'show_hidden'      => $request['hidden'],
+				'show_hidden'      => true,
 			)
 		);
 


### PR DESCRIPTION
When posting an activity into a private or hidden group, the response does not include the posted activity because in this case `$request['hidden']` is not set.

Using `true` for the `show_hidden` argument used into `bp_activity_get` seems fine as anyway the activity has been created by the user, I don't see any reason preventing him to be able to read it 😃 

I've added some tests for the `create_item` method and one for the `update_item` method to make sure this issue wasn't also appearing when updating an activity of a non public group.