### PR TITLE
Update wrong HTTP status codes

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -601,7 +601,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				'bp_rest_authorization_required',
 				__( 'Sorry, you are not allowed to update this activity.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -363,7 +363,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				'bp_rest_create_activity_empty_content',
 				__( 'Please, enter some content.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 400,
 				)
 			);
 		}
@@ -517,7 +517,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 				'bp_rest_update_activity_empty_content',
 				__( 'Please, enter some content.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 400,
 				)
 			);
 		}

--- a/includes/bp-attachments/classes/trait-attachments.php
+++ b/includes/bp-attachments/classes/trait-attachments.php
@@ -130,7 +130,7 @@ trait BP_REST_Attachments {
 					(int) $cover_dimensions['height']
 				),
 				array(
-					'status'     => 500,
+					'status'     => 400,
 					'reason'     => 'image_too_small',
 					'min_width'  => (int) $cover_dimensions['width'],
 					'min_height' => (int) $cover_dimensions['height'],
@@ -210,7 +210,7 @@ trait BP_REST_Attachments {
 					$full_height
 				),
 				array(
-					'status'     => 500,
+					'status'     => 400,
 					'reason'     => 'image_too_small',
 					'min_width'  => $full_width,
 					'min_height' => $full_height,

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -118,7 +118,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 					'bp_rest_blogs_get_items_user_failed',
 					__( 'There was a problem confirming if user ID provided is a valid one.', 'buddypress' ),
 					array(
-						'status' => 500,
+						'status' => 404,
 					)
 				);
 			}

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -209,7 +209,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 					'bp_rest_component_already_active',
 					__( 'Sorry, this component is already active.', 'buddypress' ),
 					array(
-						'status' => 500,
+						'status' => 400,
 					)
 				);
 			}
@@ -221,7 +221,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 					'bp_rest_component_inactive',
 					__( 'Sorry, this component is not active.', 'buddypress' ),
 					array(
-						'status' => 500,
+						'status' => 400,
 					)
 				);
 			}
@@ -231,7 +231,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 					'bp_rest_required_component',
 					__( 'Sorry, you cannot deactivate a required component.', 'buddypress' ),
 					array(
-						'status' => 500,
+						'status' => 400,
 					)
 				);
 			}

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -198,7 +198,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 				'bp_rest_component_nonexistent',
 				__( 'Sorry, this component does not exist.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 404,
 				)
 			);
 		}

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -131,7 +131,7 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'bp_rest_friends_get_items_user_failed',
 				__( 'There was a problem confirming if user is valid.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 404,
 				)
 			);
 		}
@@ -304,7 +304,7 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'bp_rest_friends_create_item_failed',
 				__( 'There was a problem confirming if user is valid.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 404,
 				)
 			);
 		}
@@ -426,7 +426,7 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'bp_rest_friends_update_item_failed',
 				__( 'There was a problem confirming if user is valid.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 404,
 				)
 			);
 		}
@@ -521,7 +521,7 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'bp_rest_friends_delete_item_failed',
 				__( 'There was a problem confirming if user is valid.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 404,
 				)
 			);
 		}

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -328,7 +328,7 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'bp_rest_friends_create_item_failed',
 				__( 'You are not allowed to perform this action.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 403,
 				)
 			);
 		}

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -256,7 +256,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_invites_cannot_get_items',
 				__( 'Sorry, you are not allowed to fetch group invitations with those arguments.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -350,7 +350,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_invites_cannot_get_item',
 				__( 'Sorry, you are not allowed to fetch an invitation.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -481,7 +481,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_invite_cannot_create_item',
 				__( 'Sorry, you are not allowed to create the invitation as requested.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -587,7 +587,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_invite_cannot_update_item',
 				__( 'Sorry, you are not allowed to accept the invitation as requested.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -714,7 +714,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_invite_cannot_delete_item',
 				__( 'Sorry, you are not allowed to delete the invitation as requested.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -231,7 +231,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_membership_requests_cannot_get_items',
 				__( 'Sorry, you are not allowed to view membership requests.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -318,7 +318,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_membership_requests_cannot_get_item',
 				__( 'Sorry, you are not allowed to view a membership request.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -461,7 +461,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_membership_requests_cannot_create_item',
 				__( 'User may not extend requests on behalf of another user.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -567,7 +567,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_member_request_cannot_update_item',
 				__( 'User is not allowed to approve membership requests to this group.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}
@@ -694,7 +694,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'bp_rest_group_membership_requests_cannot_delete_item',
 				__( 'User is not allowed to delete this membership request.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => rest_authorization_required_code(),
 				)
 			);
 		}

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -312,7 +312,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				'bp_rest_create_group_empty_name',
 				__( 'Please, enter the name of group.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 400,
 				)
 			);
 		}

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -463,7 +463,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 				'bp_rest_notification_invalid_id',
 				__( 'Invalid notification ID.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 404,
 				)
 			);
 		}

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -321,7 +321,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 				'bp_rest_required_param_missing',
 				__( 'Required param missing.', 'buddypress' ),
 				array(
-					'status' => 500,
+					'status' => 400,
 				)
 			);
 		}

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -302,7 +302,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$a_ids = wp_list_pluck( $response->get_data(), 'id' );
-		
+
 		$this->assertContains( $a1, $a_ids );
 		$this->assertContains( $a2, $a_ids );
 	}
@@ -866,7 +866,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -517,7 +517,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_create_activity_empty_content', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_create_activity_empty_content', $response, 400 );
 	}
 
 	/**
@@ -739,7 +739,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_create_activity_empty_content', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_create_activity_empty_content', $response, 400 );
 	}
 
 	/**
@@ -888,7 +888,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_update_activity_empty_content', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_update_activity_empty_content', $response, 400 );
 	}
 
 	/**

--- a/tests/attachments/test-blog-avatar-controller.php
+++ b/tests/attachments/test-blog-avatar-controller.php
@@ -76,7 +76,7 @@ class BP_Test_REST_Attachments_Blog_Avatar_Endpoint extends WP_Test_REST_Control
 			]
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'bp_rest_blog_avatar_get_item_user_failed', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_blog_avatar_get_item_user_failed', $response, 404 );
 	}
 
 	/**

--- a/tests/components/test-controller.php
+++ b/tests/components/test-controller.php
@@ -170,7 +170,7 @@ class BP_Test_REST_Components_Endpoint extends WP_Test_REST_Controller_Testcase 
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_component_nonexistent', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_component_nonexistent', $response, 404 );
 	}
 
 	/**

--- a/tests/friends/test-controller.php
+++ b/tests/friends/test-controller.php
@@ -345,7 +345,7 @@ class BP_Test_REST_Friends_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_friends_update_item_failed', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_friends_update_item_failed', $response, 404 );
 	}
 
 	/**
@@ -486,7 +486,7 @@ class BP_Test_REST_Friends_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'DELETE', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_friends_delete_item_failed', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_friends_delete_item_failed', $response, 404 );
 	}
 
 	/**

--- a/tests/friends/test-controller.php
+++ b/tests/friends/test-controller.php
@@ -205,7 +205,7 @@ class BP_Test_REST_Friends_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_friends_create_item_failed', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_friends_create_item_failed', $response, 403 );
 	}
 
 	/**

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -436,7 +436,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_create_group_empty_name', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_create_group_empty_name', $response, 400 );
 	}
 
 	/**

--- a/tests/groups/test-group-invites-controller.php
+++ b/tests/groups/test-group-invites-controller.php
@@ -246,7 +246,7 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_invites_cannot_get_items', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_invites_cannot_get_items', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -478,7 +478,7 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_invite_cannot_create_item', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_invite_cannot_create_item', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -580,7 +580,7 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$request  = new WP_REST_Request( 'PUT', $this->endpoint_url . '/' . $invite_id );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_invite_cannot_update_item', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_invite_cannot_update_item', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -735,7 +735,7 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_invite_cannot_delete_item', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_invite_cannot_delete_item', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/membership/test-group-membership-request-controller.php
+++ b/tests/membership/test-group-membership-request-controller.php
@@ -173,7 +173,7 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_get_items', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_get_items', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -193,7 +193,7 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_get_items', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_get_items', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_get_item', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_get_item', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -492,7 +492,7 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_member_request_cannot_update_item', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_member_request_cannot_update_item', $response, rest_authorization_required_code() );
 	}
 
 	/**
@@ -601,7 +601,7 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_delete_item', $response, 500 );
+		$this->assertErrorResponse( 'bp_rest_group_membership_requests_cannot_delete_item', $response, rest_authorization_required_code() );
 	}
 
 	/**


### PR DESCRIPTION
Hey team :hand:,

We should return `4xx` error code instead of `500` for bad requests like `empty_content`, `invalid_id` etc.  A `500` error code is for internal server errors.

I updated some of them and I'll keep update but I'm open to help and any suggestions.