### PR TITLE
Removing support to WordPress 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ matrix:
       env: WP_VERSION=5.0
     - php: 7.2
       env: WP_VERSION=4.9
-    - php: 7.2
-      env: WP_VERSION=4.8
     - php: 7.1
       env: WP_VERSION=master
     - php: 7.1
@@ -63,8 +61,6 @@ matrix:
       env: WP_VERSION=5.0
     - php: 5.6
       env: WP_VERSION=4.9
-    - php: 5.6
-      env: WP_VERSION=4.8
   allow_failures:
     - php: 7.4
 

--- a/bp-rest.php
+++ b/bp-rest.php
@@ -7,8 +7,8 @@
  * Author URI: https://buddypress.org/
  * Version: 0.3.0
  * Text Domain: buddypress
- * Requires at least: 4.8
- * Tested up to: 5.4
+ * Requires at least: 4.9
+ * Tested up to: 5.6
  * Requires PHP: 5.6
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
As BuddyPress core is removing its support from WordPress 4.9: https://buddypress.trac.wordpress.org/ticket/8318 The REST API is following suit. :)