### PR TITLE
Raising WordPress required version to 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ matrix:
       env: WP_VERSION=5.0
     - php: 7.2
       env: WP_VERSION=4.9
-    - php: 7.2
-      env: WP_VERSION=4.8
     - php: 7.1
       env: WP_VERSION=master
     - php: 7.1
@@ -63,8 +61,6 @@ matrix:
       env: WP_VERSION=5.0
     - php: 5.6
       env: WP_VERSION=4.9
-    - php: 5.6
-      env: WP_VERSION=4.8
   allow_failures:
     - php: 7.4
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please use and provide feedback!
 ## System Requirements
 
 * PHP >= 5.6
-* WP >= 4.8
+* WP >= 4.9
 * BuddyPress = trunk
 
 ## Endpoints (Components) Supported

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please use and provide feedback!
 
 ## Installation
 
-Drop this plugin in the wp-content/plugins directory and activate it. You need at least [WordPress 4.8](https://wordpress.org/download/) and [BuddyPress](https://buddypress.org/download/) to use the plugin.
+Drop this plugin in the wp-content/plugins directory and activate it. You need at least [WordPress 4.9](https://wordpress.org/download/) and [BuddyPress](https://buddypress.org/download/) to use the plugin.
 
 ## About
 

--- a/bp-rest.php
+++ b/bp-rest.php
@@ -7,8 +7,8 @@
  * Author URI: https://buddypress.org/
  * Version: 0.3.0
  * Text Domain: buddypress
- * Requires at least: 4.8
- * Tested up to: 5.4
+ * Requires at least: 4.9
+ * Tested up to: 5.6
  * Requires PHP: 5.6
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bp-rest.php
+++ b/bp-rest.php
@@ -8,7 +8,7 @@
  * Version: 0.3.0
  * Text Domain: buddypress
  * Requires at least: 4.9
- * Tested up to: 5.6
+ * Tested up to: 5.4
  * Requires PHP: 5.6
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === BP-REST ===
 Contributors:      The BuddyPress Community
 Donate link:       https://buddypress.org
-Requires at least: 4.8
+Requires at least: 4.9
 Tested up to:      5.4
-Stable tag:        0.1.0
+Requires PHP:      5.6
+Stable tag:        0.3.0
 License:           GPLv2
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
As BuddyPress core is raising its support to WordPress 4.9: https://buddypress.trac.wordpress.org/ticket/8318 The REST API is following suit. :)