### PR TITLE
Profile Data Update

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1057,7 +1057,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	 * @return array Endpoint arguments.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
-		$args = WP_REST_Controller::get_endpoint_args_for_item_schema( $method );
+		$args = parent::get_endpoint_args_for_item_schema( $method );
 		$key  = 'get_item';
 
 		if ( WP_REST_Server::CREATABLE === $method || WP_REST_Server::EDITABLE === $method ) {

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -50,10 +50,12 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 				'args'   => array(
 					'field_id' => array(
 						'description' => __( 'The ID of the field the data is from.', 'buddypress' ),
+						'required'    => true,
 						'type'        => 'integer',
 					),
 					'user_id'  => array(
 						'description' => __( 'The ID of user the field data is from.', 'buddypress' ),
+						'required'    => true,
 						'type'        => 'integer',
 					),
 				),
@@ -68,15 +70,9 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => array(
 						'value' => array(
-							'description' => __( 'The list of values for the field data.', 'buddypress' ),
-							'type'        => 'array',
-							'items'       => array(
-								'type' => 'string',
-							),
-							'arg_options' => array(
-								'validate_callback' => 'rest_validate_request_arg',
-								'sanitize_callback' => 'rest_sanitize_request_arg',
-							),
+							'description' => __( 'The value(s) for the field data.', 'buddypress' ),
+							'required'    => true,
+							'type'        => 'string',
 						),
 					),
 				),
@@ -215,7 +211,9 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		 * the submitted value was not an array.
 		 */
 		if ( ! $field->type_obj->supports_multiple_defaults ) {
-			$value = implode( ' ', $value );
+			$value = implode( ' ', (array) $value );
+		} else {
+			$value = preg_split( '/[,]+/', $value );
 		}
 
 		if ( ! xprofile_set_field_data( $field->id, $user->ID, $value ) ) {


### PR DESCRIPTION
fixes #324 

I'm suggesting an update at how we parse the strings when updating a profile field. Currently the value that's being passed goes to `wp_parse_list` which is splitting the array/value incorrectly.

A list like so: `Select 01, Select 02` will be converted as `["Select","01","Select","02"]` instead of `["Select 01","Select 02"]`. The main issue is the regex used: `/[\s,]+/` which takes into account spacing when splitting the array, causing the bug.

So to avoid this bug, I opted to pass the value as a string and split it accordingly before the profile field update. First, we check if the field `supports_multiple_defaults`, if it doesn't, we pass it as a string. If it does, we split it as it accepts an array with multiple values.

This is a breaking change, though. Since we are moving the `value` field from an `array` type to a `string` type.