### PR TITLE
Improving fetching of activities from private groups

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -164,7 +164,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			$args['since'] = $request['after'];
 		}
 
-		if ( isset( $request['user_id'] ) ) {
+		if ( ! empty( $request['user_id'] ) ) {
 			$args['filter']['user_id'] = $request['user_id'];
 		}
 
@@ -172,6 +172,10 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( ! empty( $args['group_id'] ) ) {
 			$args['filter']['object']     = 'groups';
 			$args['filter']['primary_id'] = $args['group_id'];
+
+			if ( empty( $request['component'] ) ) {
+				$request['component'] = 'groups';
+			}
 
 			$item_id = $args['group_id'];
 		}
@@ -184,7 +188,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		}
 
 		if ( empty( $args['group_id'] ) && empty( $args['site_id'] ) ) {
-			if ( isset( $request['component'] ) ) {
+			if ( ! empty( $request['component'] ) ) {
 				$args['filter']['object'] = $request['component'];
 			}
 

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -271,6 +271,133 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_items
 	 */
+	public function test_get_private_group_items_without_access() {
+		$component = buddypress()->groups->id;
+
+		$u = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->bp->set_current_user( $u );
+
+		// Current user is $u.
+		$g1 = $this->bp_factory->group->create( array(
+			'status'     => 'private',
+			'creator_id' => $this->user,
+		) );
+
+		$a1 = $this->bp_factory->activity->create( array(
+			'component'     => $component,
+			'type'          => 'created_group',
+			'user_id'       => $this->user,
+			'item_id'       => $g1,
+			'hide_sitewide' => true,
+		) );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_query_params( array(
+			'component'  => $component,
+			'primary_id' => $g1,
+		) );
+
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$a_ids = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertEmpty( $a_ids );
+		$this->assertNotContains( $a1, $a_ids );
+	}
+
+	/**
+	 * @group get_items
+	 */
+	public function test_get_private_group_items_with_the_group_id_param() {
+		$component = buddypress()->groups->id;
+
+		$u = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->bp->set_current_user( $u );
+
+		// Current user is $u.
+		$g1 = $this->bp_factory->group->create( array(
+			'status'     => 'private',
+			'creator_id' => $u,
+		) );
+
+		$g2 = $this->bp_factory->group->create( array(
+			'status'     => 'public',
+			'creator_id' => $this->user,
+		) );
+
+		$a1 = $this->bp_factory->activity->create( array(
+			'component'     => $component,
+			'type'          => 'created_group',
+			'user_id'       => $u,
+			'item_id'       => $g1,
+			'hide_sitewide' => true,
+		) );
+
+		$a2 = $this->bp_factory->activity->create( array(
+			'component' => $component,
+			'type'      => 'created_group',
+			'user_id'   => $this->user,
+			'item_id'   => $g2,
+		) );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_query_params( array(
+			'group_id' => $g1,
+		) );
+
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$a_ids = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertNotContains( $a2, $a_ids );
+		$this->assertContains( $a1, $a_ids );
+	}
+
+	/**
+	 * @group get_items
+	 */
+	public function test_get_private_group_items_with_group_id_param_without_access() {
+		$component = buddypress()->groups->id;
+
+		$u = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->bp->set_current_user( $u );
+
+		// Current user is $u.
+		$g1 = $this->bp_factory->group->create( array(
+			'status'     => 'private',
+			'creator_id' => $this->user,
+		) );
+
+		$a1 = $this->bp_factory->activity->create( array(
+			'component'     => $component,
+			'type'          => 'created_group',
+			'user_id'       => $this->user,
+			'item_id'       => $g1,
+			'hide_sitewide' => true,
+		) );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_query_params( array(
+			'group_id' => $g1,
+		) );
+
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$a_ids = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertEmpty( $a_ids );
+		$this->assertNotContains( $a1, $a_ids );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_paginated_items() {
 		$u = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$this->bp->set_current_user( $u );


### PR DESCRIPTION
fixes #353 

With this change, one can fetch activities from a group (private or not) in two ways:

`wp-json/buddypress/v1/activity?primary_id=1&component=custom`
`wp-json/buddypress/v1/activity?group_id=1`