### PR TITLE
Improve the way the last activity is set for the current user

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -479,7 +479,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			$data['last_activity']['date']     = '';
 
 			if ( get_current_user_id() === $user->ID ) {
-				$right_now                         = date( 'Y-m-d H:i:s', bp_core_current_time( true, 'timestamp' ) );
+				$right_now                         = gmdate( 'Y-m-d H:i:s', bp_core_current_time( true, 'timestamp' ) );
 				$data['last_activity']['timediff'] = bp_core_time_since( $right_now );
 				$data['last_activity']['date']     = bp_rest_prepare_date_response( $right_now );
 

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -475,12 +475,17 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		);
 
 		if ( $request->get_param( 'populate_extras' ) ) {
-			if ( $user->last_activity ) {
+			$data['last_activity']['timediff'] = '';
+			$data['last_activity']['date']     = '';
+
+			if ( get_current_user_id() === $user->ID ) {
+				$right_now                         = date( 'Y-m-d H:i:s', bp_core_current_time( true, 'timestamp' ) );
+				$data['last_activity']['timediff'] = bp_core_time_since( $right_now );
+				$data['last_activity']['date']     = bp_rest_prepare_date_response( $right_now );
+
+			} elseif ( $user->last_activity ) {
 				$data['last_activity']['timediff'] = bp_core_time_since( $user->last_activity );
 				$data['last_activity']['date']     = bp_rest_prepare_date_response( $user->last_activity );
-			} else {
-				$data['last_activity']['timediff'] = '';
-				$data['last_activity']['date']     = '';
 			}
 
 			if ( bp_is_active( 'activity' ) ) {

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -99,7 +99,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$u2 = $this->factory->user->create();
 		$u3 = $this->factory->user->create();
 
-		// Register and set member types.
+		// Set current user.
 		$current_user = get_current_user_id();
 		$this->bp->set_current_user( $u2 );
 
@@ -208,7 +208,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$u1 = $this->factory->user->create();
 		$u2 = $this->factory->user->create();
 
-		// Register and set member types.
+		// Set current user.
 		$current_user = get_current_user_id();
 		$this->bp->set_current_user( $u1 );
 
@@ -240,6 +240,31 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( bp_rest_prepare_date_response( $date_last_activity ), $member['last_activity']['date'] );
 		$this->assertEquals( $member['latest_update']['id'], $a1 );
 		$this->assertEquals( 1, $member['total_friend_count'] );
+
+		$this->bp->set_current_user( $current_user );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_me_extras() {
+		// Set current user.
+		$current_user = get_current_user_id();
+		$this->bp->set_current_user( self::$user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint_url . '/me' );
+		$request->set_query_params(
+			array(
+				'populate_extras' => true,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$me = $response->get_data();
+
+		$this->assertEquals( 'right now', $me['last_activity']['timediff'] );
 
 		$this->bp->set_current_user( $current_user );
 	}


### PR DESCRIPTION
To set the current user's last activity into `BP_REST_Members_Endpoint::user_data()` we should use the current time.