### PR TITLE
Take in account BP 7.0.0 changes about default blavatar

### DIFF
--- a/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
@@ -83,7 +83,9 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
-		if ( empty( $this->blog->admin_user_id ) ) {
+		$no_user_grav = (bool) $request->get_param( 'no_user_gravatar' );
+
+		if ( empty( $this->blog->admin_user_id ) && ! $no_user_grav ) {
 			return new WP_Error(
 				'bp_rest_blog_avatar_get_item_user_failed',
 				__( 'There was a problem confirming the blog\'s user admin is valid.', 'buddypress' ),
@@ -93,20 +95,29 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		$admin_user_admin = (int) $this->blog->admin_user_id;
+		// Set the requested args.
+		$requested_args = array(
+			'blog_id' => $request['id'],
+			'no_grav' => $no_user_grav,
+			'html'    => (bool) $request['html'],
+		);
+
+		if ( $request['alt'] ) {
+			$requested_args['alt'] = $request['alt'];
+		}
+
+		if ( ! $no_user_grav ) {
+			$requested_args['admin_user_id'] = (int) $this->blog->admin_user_id;
+
+			if ( ! isset( $requested_args['alt'] ) ) {
+				$requested_args['alt'] = '';
+			}
+		}
 
 		$args = array();
 		foreach ( array( 'full', 'thumb' ) as $type ) {
-			$args[ $type ] = bp_get_blog_avatar(
-				array(
-					'type'          => $type,
-					'blog_id'       => $request['id'],
-					'admin_user_id' => $admin_user_admin,
-					'html'          => (bool) $request['html'],
-					'alt'           => $request['alt'],
-					'no_grav'       => (bool) $request['no_user_gravatar'],
-				)
-			);
+			$requested_args['type'] = $type;
+			$args[ $type ]          = bp_get_blog_avatar( $requested_args );
 		}
 
 		// Get the avatar object.


### PR DESCRIPTION
If the `no_user_grav` param is set to true, then the blavatar fetched will be the default one.
Add unit tests to check the 3 available scenario when fetching the blog avatar:
- site icon is used
- no user gravatar is requested
- use the admin user avatar

See: https://buddypress.trac.wordpress.org/changeset/12772