### PR TITLE
Do assign member types into the Members Endpoint

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -581,7 +581,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		}
 
 		/**
-		 * Untill version 7.0.0 the `types` parameter was used into the schema
+		 * Until BP REST version 0.3.0 the `types` parameter was used into the schema
 		 * but not used to actually assign the member type to the user.
 		 */
 		$types = $request->get_param( 'types' );

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -65,7 +65,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
-					'args'                => parent::get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
@@ -580,6 +580,15 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			$prepared_user->user_login = $request['user_login'];
 		}
 
+		/**
+		 * Untill version 7.0.0 the `types` parameter was used into the schema
+		 * but not used to actually assign the member type to the user.
+		 */
+		$types = $request->get_param( 'types' );
+		if ( $types ) {
+			$request->set_param( 'member_type', bp_rest_sanitize_member_types( $types ) );
+		}
+
 		// Set member type.
 		if ( isset( $prepared_user->ID ) && isset( $request['member_type'] ) ) {
 
@@ -705,7 +714,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 
 		// Add member type args.
 		$member_type_args = array(
-			'description'       => __( 'Set type(s) for a member.', 'buddypress' ),
+			'description'       => __( 'Assign a member type to a member, use a comma separated list of member types to assign more than one.', 'buddypress' ),
 			'type'              => 'string',
 			'enum'              => bp_get_member_types(),
 			'context'           => array( 'edit' ),
@@ -720,7 +729,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			unset( $args['mention_name'] );
 
 			// Add member type args.
-			$args['types'] = $member_type_args;
+			$args['member_type'] = $member_type_args;
 
 			// But we absolutely need the email.
 			$args['email'] = array(
@@ -740,7 +749,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			unset( $args['mention_name'], $args['user_login'], $args['password'] );
 
 			// Add member type args.
-			$args['types'] = $member_type_args;
+			$args['member_type'] = $member_type_args;
 		} elseif ( WP_REST_Server::DELETABLE === $method ) {
 			$key = 'delete_item';
 		}

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -405,6 +405,65 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * This test is there to make sure we are handling the `types` parameter
+	 * that was used before version 0.3.0 of the plugin and BuddyPress 7.0.0.
+	 *
+	 * @group update_item
+	 */
+	public function test_update_item_types() {
+		$u = $this->factory->user->create( array(
+			'email' => 'member@type.com',
+			'name'  => 'User Name',
+		) );
+
+		$this->bp->set_current_user( self::$user );
+		bp_register_member_type( 'membertypeone' );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $u ) );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params( array(
+			'types' => 'membertypeone',
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$member_type = reset( $data['member_types'] );
+
+		$this->assertSame( 'membertypeone', $member_type );
+	}
+
+	/**
+	 * This test is there to make sure we are handling the `types` parameter
+	 * that was used before version 0.3.0 of the plugin and BuddyPress 7.0.0.
+	 *
+	 * @group update_item
+	 */
+	public function test_update_item_member_type() {
+		$u = $this->factory->user->create( array(
+			'email' => 'member@type.com',
+			'name'  => 'User Name',
+		) );
+
+		$this->bp->set_current_user( self::$user );
+		bp_register_member_type( 'membertypeone' );
+		bp_register_member_type( 'membertypetwo' );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $u ) );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params( array(
+			'member_type' => 'membertypeone,membertypetwo',
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$member_types = array( 'membertypeone' ,'membertypetwo' );
+
+		$this->assertSame( $data['member_types'], $member_types );
+	}
+
+	/**
 	 * @group delete_item
 	 */
 	public function test_delete_item() {

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -406,7 +406,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * This test is there to make sure we are handling the `types` parameter
-	 * that was used before version 0.3.0 of the plugin and BuddyPress 7.0.0.
+	 * that was used before BP REST 0.3.0 and BuddyPress 7.0.0.
 	 *
 	 * @group update_item
 	 */
@@ -434,9 +434,6 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 * This test is there to make sure we are handling the `types` parameter
-	 * that was used before version 0.3.0 of the plugin and BuddyPress 7.0.0.
-	 *
 	 * @group update_item
 	 */
 	public function test_update_item_member_type() {


### PR DESCRIPTION
Working on documentation updates, I noticed the `types` parameter of the documentation wasn't used by create/update methods. Instead we were using a `member_type` parameter that wasn't sanitized. This was probably due to the fact until BuddyPress 7.0.0 it wasn't possible to assign more than one member type to a member. As `bp_rest_sanitize_member_types()` is returning an array, it was causing an error in BuddyPress.

In BuddyPress 7.0.0, it's now possible to set multiple member types to a member. That's why I edited the schema for create/update methods so that it actually uses the `member_type` parameter and in case some people are using the `types` one it will be used to set the `member_type` parameter into the `BP_REST_Members_Endpoint->prepare_item_for_database()` method.

I've added 2 unit tests to check Member types are actually assigned using `member_type` or its alias `types`.