### PR TITLE
Improve the member_types property of the members endpoint item schema

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -819,7 +819,11 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				),
 				'member_types'       => array(
 					'description' => __( 'Member types associated with the member.', 'buddypress' ),
-					'type'        => 'object',
+					'enum'        => bp_get_member_types(),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+					),
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
The `members_type` property of the item schema should be an array instead of an object. I've updated this property in a similar way then what we're doing for the Groups endpoints types item schema property. I've also added unit tests for both endpoints.