### PR TITLE
Avoid a PHP 8.0 deprecated notice about optional function arg.

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -458,7 +458,11 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
-	public function user_data( $user, $context = 'view', $request ) {
+	public function user_data( $user, $context, $request ) {
+		if ( ! $context ) {
+			$context = 'view';
+		}
+
 		$data = array(
 			'id'                     => $user->ID,
 			'name'                   => $user->display_name,

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -282,7 +282,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 	 * @param integer         $field_id The profile field object ID.
 	 * @param WP_REST_Request $request  The request sent to the API.
 	 */
-	public function set_additional_field_properties( $field_id = 0, WP_REST_Request $request ) {
+	public function set_additional_field_properties( $field_id, WP_REST_Request $request ) {
 		if ( ! $field_id ) {
 			return;
 		}

--- a/tests/attachments/test-group-avatar-controller.php
+++ b/tests/attachments/test-group-avatar-controller.php
@@ -155,7 +155,7 @@ class BP_Test_REST_Attachments_Group_Avatar_Endpoint extends WP_Test_REST_Contro
 		$_POST  = $reset_post;
 	}
 
-	public function copy_file( $return = null, $file, $new_file ) {
+	public function copy_file( $return, $file, $new_file ) {
 		return @copy( $file['tmp_name'], $new_file );
 	}
 

--- a/tests/attachments/test-member-avatar-controller.php
+++ b/tests/attachments/test-member-avatar-controller.php
@@ -156,7 +156,7 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 		$_POST  = $reset_post;
 	}
 
-	public function copy_file( $return = null, $file, $new_file ) {
+	public function copy_file( $return, $file, $new_file ) {
 		return @copy( $file['tmp_name'], $new_file );
 	}
 


### PR DESCRIPTION
PHP 8.0 no longer accepts a required argument to follow an optional one into functions.