### PR TITLE
0.4.0 version bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,19 +39,19 @@ jobs:
     - php: 7.4
       env: WP_VERSION=master PHPCS=1 BUILD=1
     - php: 7.4
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
     - php: 7.4
       env: WP_VERSION=5.3
     - php: 7.3
       env: WP_VERSION=master PHPCS=1 BUILD=1
     - php: 7.3
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
     - php: 7.3
       env: WP_VERSION=5.0
     - php: 7.2
       env: WP_VERSION=master
     - php: 7.2
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
     - php: 7.2
       env: WP_VERSION=5.0
     - php: 7.2
@@ -59,17 +59,17 @@ jobs:
     - php: 7.1
       env: WP_VERSION=master
     - php: 7.1
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
     - php: 7.1
       env: WP_VERSION=5.0
     - php: 7.0
       env: WP_VERSION=master
     - php: 7.0
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
     - php: 5.6
       env: WP_VERSION=master
     - php: 5.6
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
     - php: 5.6
       env: WP_VERSION=5.0
     - php: 5.6

--- a/bp-rest.php
+++ b/bp-rest.php
@@ -5,10 +5,10 @@
  * Description: BuddyPress extension for WordPress' JSON-based REST API.
  * Author: The BuddyPress Community
  * Author URI: https://buddypress.org/
- * Version: 0.3.0
+ * Version: 0.4.0
  * Text Domain: buddypress
  * Requires at least: 4.9
- * Tested up to: 5.4
+ * Tested up to: 5.6
  * Requires PHP: 5.6
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bp-rest",
   "title": "BP-REST",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Access your BuddyPress site's data through an easy-to-use HTTP REST API.",
   "keywords": [
     "BuddyPress",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Check against minimum WP version. -->
-	<config name="minimum_supported_wp_version" value="4.8"/>
+	<config name="minimum_supported_wp_version" value="4.9"/>
 
 	<!-- Load WordPress Coding standards -->
 	<rule ref="WordPress"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="default">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      The BuddyPress Community
 Donate link:       https://buddypress.org
 Requires at least: 4.9
-Tested up to:      5.4
+Tested up to:      5.6
 Requires PHP:      5.6
 Stable tag:        0.3.0
 License:           GPLv2


### PR DESCRIPTION
From now on we need to use `@since 8.0.0` for new introduced functions/classes as this will be included into BuddyPress 8.0.0. FYI, the 0.3 branch has been created for the BuddyPress 7.0 branch