### PR TITLE
Caching schema in REST controllers

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1415,12 +1415,17 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the activity schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_activity_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_activity_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -929,7 +929,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! empty( $schema['properties']['user_avatar'] ) ) {
+		if ( true === buddypress()->avatar->show_avatars ) {
 			$data['user_avatar'] = array(
 				'full'  => bp_core_fetch_avatar(
 					array(

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1262,161 +1262,160 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_activity',
-			'type'       => 'object',
-			'properties' => array(
-				'id'                => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the activity.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'primary_item_id'   => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of some other object primarily associated with this one.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'secondary_item_id' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of some other object also associated with this one.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'user_id'           => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID for the author of the activity.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'link'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The permalink to this activity on the site.', 'buddypress' ),
-					'format'      => 'uri',
-					'type'        => 'string',
-				),
-				'component'         => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The active BuddyPress component the activity relates to.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => array_keys( buddypress()->active_components ),
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
-				'type'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The activity type of the activity.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => array_keys( bp_activity_get_types() ),
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
-				'title'             => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The description of the activity\'s type (eg: Username posted an update)', 'buddypress' ),
-					'type'        => 'string',
-					'readonly'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-				'content'           => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Allowed HTML content for the activity.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the activity, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the activity, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-				'date'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date the activity was published, in the site's timezone.", 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-				'status'            => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the activity has been marked as spam or not.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => array( 'published', 'spam' ),
-					'readonly'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
-				'comments'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A list of objects children of the activity object.', 'buddypress' ),
-					'type'        => 'array',
-					'readonly'    => true,
-				),
-				'comment_count'     => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Total number of comments of the activity object.', 'buddypress' ),
-					'type'        => 'integer',
-					'readonly'    => true,
-				),
-				'hidden'            => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'Whether the activity object should be sitewide hidden or not.', 'buddypress' ),
-					'type'        => 'boolean',
-				),
-				'favorited'         => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the activity object has been favorited by the current user.', 'buddypress' ),
-					'type'        => 'boolean',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Avatars.
-		if ( true === buddypress()->avatar->show_avatars ) {
-			$avatar_properties = array();
-
-			$avatar_properties['full'] = array(
-				'context'     => array( 'view', 'edit' ),
-				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-			);
-
-			$avatar_properties['thumb'] = array(
-				'context'     => array( 'view', 'edit' ),
-				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-			);
-
-			$schema['properties']['user_avatar'] = array(
-				'context'     => array( 'view', 'edit' ),
-				'description' => __( 'Avatar URLs for the author of the activity.', 'buddypress' ),
-				'type'        => 'object',
-				'readonly'    => true,
-				'properties'  => $avatar_properties,
-			);
-		}
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_activity',
+				'type'       => 'object',
+				'properties' => array(
+					'id'                => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the activity.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'primary_item_id'   => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of some other object primarily associated with this one.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'secondary_item_id' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of some other object also associated with this one.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'user_id'           => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID for the author of the activity.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'link'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The permalink to this activity on the site.', 'buddypress' ),
+						'format'      => 'uri',
+						'type'        => 'string',
+					),
+					'component'         => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The active BuddyPress component the activity relates to.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => array_keys( buddypress()->active_components ),
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_key',
+						),
+					),
+					'type'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The activity type of the activity.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => array_keys( bp_activity_get_types() ),
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_key',
+						),
+					),
+					'title'             => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The description of the activity\'s type (eg: Username posted an update)', 'buddypress' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+					'content'           => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Allowed HTML content for the activity.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+							'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the activity, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the activity, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'date'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date the activity was published, in the site's timezone.", 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+					'status'            => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the activity has been marked as spam or not.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => array( 'published', 'spam' ),
+						'readonly'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_key',
+						),
+					),
+					'comments'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A list of objects children of the activity object.', 'buddypress' ),
+						'type'        => 'array',
+						'readonly'    => true,
+					),
+					'comment_count'     => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Total number of comments of the activity object.', 'buddypress' ),
+						'type'        => 'integer',
+						'readonly'    => true,
+					),
+					'hidden'            => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'Whether the activity object should be sitewide hidden or not.', 'buddypress' ),
+						'type'        => 'boolean',
+					),
+					'favorited'         => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the activity object has been favorited by the current user.', 'buddypress' ),
+						'type'        => 'boolean',
+						'readonly'    => true,
+					),
+				),
+			);
+
+			if ( true === buddypress()->avatar->show_avatars ) {
+				$avatar_properties = array();
+
+				$avatar_properties['full'] = array(
+					'context'     => array( 'view', 'edit' ),
+					/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
+					'type'        => 'string',
+					'format'      => 'uri',
+				);
+
+				$avatar_properties['thumb'] = array(
+					'context'     => array( 'view', 'edit' ),
+					/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
+					'type'        => 'string',
+					'format'      => 'uri',
+				);
+
+				$schema['properties']['user_avatar'] = array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'Avatar URLs for the author of the activity.', 'buddypress' ),
+					'type'        => 'object',
+					'readonly'    => true,
+					'properties'  => $avatar_properties,
+				);
+			}
+
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
@@ -245,31 +245,28 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_attachments_blog_avatar',
-			'type'       => 'object',
-			'properties' => array(
-				'full'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Full size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'thumb' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Thumb size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_attachments_blog_avatar',
+				'type'       => 'object',
+				'properties' => array(
+					'full'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Full size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+					'thumb' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Thumb size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
@@ -267,12 +267,17 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the blog avatar schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_attachments_blog_avatar_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_attachments_blog_avatar_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -709,6 +709,11 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filter the blogs schema.
 		 *
@@ -716,7 +721,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_blogs_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_blogs_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -617,97 +617,96 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_blogs',
-			'type'       => 'object',
-			'properties' => array(
-				'id'            => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the blog.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'user_id'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the blog admin.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'name'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The name of the blog.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'string',
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
+		if ( is_null( $this->schema ) ) {
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_blogs',
+				'type'       => 'object',
+				'properties' => array(
+					'id'            => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the blog.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'user_id'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the blog admin.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'name'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The name of the blog.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+					'permalink'     => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The permalink of the blog.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'format'      => 'uri',
+					),
+					'description'   => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The description of the blog.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					),
+					'path'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The path of the blog.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					),
+					'domain'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'the domain of the blog.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					),
+					'last_activity' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The last activity date from the blog, in the site's timezone.", 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
 					),
 				),
-				'permalink'     => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The permalink of the blog.', 'buddypress' ),
-					'readonly'    => true,
+			);
+
+			if ( true === buddypress()->avatar->show_avatars ) {
+				$avatar_properties = array();
+
+				$avatar_properties['full'] = array(
+					/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
-				),
-				'description'   => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The description of the blog.', 'buddypress' ),
+				);
+
+				$avatar_properties['thumb'] = array(
+					/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+				);
+
+				$schema['properties']['avatar_urls'] = array(
+					'description' => __( 'Avatar URLs for the blog.', 'buddypress' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-					'type'        => 'string',
-				),
-				'path'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The path of the blog.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'string',
-				),
-				'domain'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'the domain of the blog.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'string',
-				),
-				'last_activity' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The last activity date from the blog, in the site's timezone.", 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-			),
-		);
+					'properties'  => $avatar_properties,
+				);
+			}
 
-		// Blog Avatars.
-		if ( true === buddypress()->avatar->show_avatars ) {
-			$avatar_properties = array();
-
-			$avatar_properties['full'] = array(
-				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'view', 'edit' ),
-			);
-
-			$avatar_properties['thumb'] = array(
-				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'view', 'edit' ),
-			);
-
-			$schema['properties']['avatar_urls'] = array(
-				'description' => __( 'Avatar URLs for the blog.', 'buddypress' ),
-				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'properties'  => $avatar_properties,
-			);
-		}
-
-		// Cache current schema here.
-		if ( is_null( $this->schema ) ) {
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -414,11 +414,8 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			'last_activity' => bp_rest_prepare_date_response( $blog->last_activity ),
 		);
 
-		// Get item schema.
-		$schema = $this->get_item_schema();
-
 		// Blog Avatars.
-		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
+		if ( true === buddypress()->avatar->show_avatars ) {
 			$data['avatar_urls'] = array(
 				'thumb' => bp_get_blog_avatar(
 					array(
@@ -681,7 +678,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 		);
 
 		// Blog Avatars.
-		if ( buddypress()->avatar->show_avatars ) {
+		if ( true === buddypress()->avatar->show_avatars ) {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -457,12 +457,17 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the components schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_components_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_components_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -428,38 +428,35 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_components',
-			'type'       => 'object',
-			'properties' => array(
-				'name'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Name of the object.', 'buddypress' ),
-					'type'        => 'string',
-				),
-				'status'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the object is active or inactive.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => array( 'active', 'inactive' ),
-				),
-				'title'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'HTML title of the object.', 'buddypress' ),
-					'type'        => 'string',
-				),
-				'description' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'HTML description of the object.', 'buddypress' ),
-					'type'        => 'string',
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_components',
+				'type'       => 'object',
+				'properties' => array(
+					'name'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Name of the object.', 'buddypress' ),
+						'type'        => 'string',
+					),
+					'status'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the object is active or inactive.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => array( 'active', 'inactive' ),
+					),
+					'title'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'HTML title of the object.', 'buddypress' ),
+						'type'        => 'string',
+					),
+					'description' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'HTML description of the object.', 'buddypress' ),
+						'type'        => 'string',
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -825,12 +825,12 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				),
 				'initiator_id' => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user who is requesting the Friendship.', 'buddypress' ),
+					'description' => __( 'The unique numeric identifier of the user who is requesting the Friendship.', 'buddypress' ),
 					'type'        => 'integer',
 				),
 				'friend_id'    => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user who is invited to agree to the Friendship request.', 'buddypress' ),
+					'description' => __( 'The unique numeric identifier of the user who is invited to agree to the Friendship request.', 'buddypress' ),
 					'type'        => 'integer',
 				),
 				'is_confirmed' => array(
@@ -849,6 +849,11 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the friends schema.
 		 *
@@ -856,7 +861,7 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_friends_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_friends_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -813,45 +813,42 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_friends',
-			'type'       => 'object',
-			'properties' => array(
-				'id'           => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Unique numeric identifier of the friendship.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'initiator_id' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The unique numeric identifier of the user who is requesting the Friendship.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'friend_id'    => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The unique numeric identifier of the user who is invited to agree to the Friendship request.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'is_confirmed' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the friendship been confirmed/accepted.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'boolean',
-				),
-				'date_created' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date the friendship was created, in the site's timezone.", 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_friends',
+				'type'       => 'object',
+				'properties' => array(
+					'id'           => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Unique numeric identifier of the friendship.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'initiator_id' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The unique numeric identifier of the user who is requesting the Friendship.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'friend_id'    => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The unique numeric identifier of the user who is invited to agree to the Friendship request.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'is_confirmed' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the friendship been confirmed/accepted.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'boolean',
+					),
+					'date_created' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date the friendship was created, in the site's timezone.", 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-groups/classes/class-bp-rest-attachments-group-avatar-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-attachments-group-avatar-endpoint.php
@@ -428,31 +428,28 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_attachments_group_avatar',
-			'type'       => 'object',
-			'properties' => array(
-				'full'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Full size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'thumb' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Thumb size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_attachments_group_avatar',
+				'type'       => 'object',
+				'properties' => array(
+					'full'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Full size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+					'thumb' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Thumb size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-groups/classes/class-bp-rest-attachments-group-avatar-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-attachments-group-avatar-endpoint.php
@@ -437,23 +437,30 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Full size of the image file.', 'buddypress' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 				'thumb' => array(
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Thumb size of the image file.', 'buddypress' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
-		 * Filters the group avatar schema.
+		 * Filters the attachments group avatar schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_attachments_group_avatar_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_attachments_group_avatar_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-attachments-group-cover-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-attachments-group-cover-endpoint.php
@@ -411,24 +411,21 @@ class BP_REST_Attachments_Group_Cover_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_attachments_group_cover',
-			'type'       => 'object',
-			'properties' => array(
-				'image' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Full size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_attachments_group_cover',
+				'type'       => 'object',
+				'properties' => array(
+					'image' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Full size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-groups/classes/class-bp-rest-attachments-group-cover-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-attachments-group-cover-endpoint.php
@@ -426,11 +426,16 @@ class BP_REST_Attachments_Group_Cover_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
-		 * Filters the group cover schema.
+		 * Filters the attachments group cover schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_attachments_group_cover_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_attachments_group_cover_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 }

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -1010,12 +1010,17 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the group invites schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_group_invites_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_group_invites_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -940,79 +940,76 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_group_invites',
-			'type'       => 'object',
-			'properties' => array(
-				'id'            => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the BP Invitation object.', 'buddypress' ),
-					'type'        => 'integer',
-					'readonly'    => true,
-				),
-				'user_id'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user who is invited to join the Group.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'invite_sent'   => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the invite has been sent to the invitee.', 'buddypress' ),
-					'type'        => 'boolean',
-				),
-				'inviter_id'    => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user who made the invite.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'group_id'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the group to which the user has been invited.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'date_modified' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date the object was created or last updated, in the site's timezone.", 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-				'type'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Invitation or request.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => array( 'invite', 'request' ),
-					'default'     => 'invite',
-				),
-				'message'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The raw and rendered versions for the content of the message.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the object, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the object, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_group_invites',
+				'type'       => 'object',
+				'properties' => array(
+					'id'            => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the BP Invitation object.', 'buddypress' ),
+						'type'        => 'integer',
+						'readonly'    => true,
+					),
+					'user_id'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the user who is invited to join the Group.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'invite_sent'   => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the invite has been sent to the invitee.', 'buddypress' ),
+						'type'        => 'boolean',
+					),
+					'inviter_id'    => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the user who made the invite.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'group_id'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the group to which the user has been invited.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'date_modified' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date the object was created or last updated, in the site's timezone.", 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+					'type'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Invitation or request.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => array( 'invite', 'request' ),
+						'default'     => 'invite',
+					),
+					'message'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The raw and rendered versions for the content of the message.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the object, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the object, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -844,46 +844,46 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-
-		// Get schema from members.
-		$schema = $this->members_endpoint->get_item_schema();
-
-		// Set title to this endpoint.
-		$schema['title'] = 'bp_group_members';
-
-		$schema['properties']['is_mod'] = array(
-			'context'     => array( 'view', 'edit' ),
-			'description' => __( 'Whether the member is a group moderator.', 'buddypress' ),
-			'type'        => 'boolean',
-		);
-
-		$schema['properties']['is_banned'] = array(
-			'context'     => array( 'view', 'edit' ),
-			'description' => __( 'Whether the member has been banned from the group.', 'buddypress' ),
-			'type'        => 'boolean',
-		);
-
-		$schema['properties']['is_admin'] = array(
-			'context'     => array( 'view', 'edit' ),
-			'description' => __( 'Whether the member is a group administrator.', 'buddypress' ),
-			'type'        => 'boolean',
-		);
-
-		$schema['properties']['is_confirmed'] = array(
-			'context'     => array( 'view', 'edit' ),
-			'description' => __( 'Whether the membership of this user has been confirmed.', 'buddypress' ),
-			'type'        => 'boolean',
-		);
-
-		$schema['properties']['date_modified'] = array(
-			'context'     => array( 'view', 'edit' ),
-			'description' => __( "The date of the last time the membership of this user was modified, in the site's timezone.", 'buddypress' ),
-			'type'        => 'string',
-			'format'      => 'date-time',
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
+
+			// Get schema from members.
+			$schema = $this->members_endpoint->get_item_schema();
+
+			// Set title to this endpoint.
+			$schema['title'] = 'bp_group_members';
+
+			$schema['properties']['is_mod'] = array(
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( 'Whether the member is a group moderator.', 'buddypress' ),
+				'type'        => 'boolean',
+			);
+
+			$schema['properties']['is_banned'] = array(
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( 'Whether the member has been banned from the group.', 'buddypress' ),
+				'type'        => 'boolean',
+			);
+
+			$schema['properties']['is_admin'] = array(
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( 'Whether the member is a group administrator.', 'buddypress' ),
+				'type'        => 'boolean',
+			);
+
+			$schema['properties']['is_confirmed'] = array(
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( 'Whether the membership of this user has been confirmed.', 'buddypress' ),
+				'type'        => 'boolean',
+			);
+
+			$schema['properties']['date_modified'] = array(
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( "The date of the last time the membership of this user was modified, in the site's timezone.", 'buddypress' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+			);
+
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -882,12 +882,17 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 			'format'      => 'date-time',
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the group membership schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_group_members_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_group_members_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -867,12 +867,17 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 		// Remove unused properties.
 		unset( $schema['properties']['invite_sent'], $schema['properties']['inviter_id'] );
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the group membership request schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_group_membership_requests_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_group_membership_requests_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -852,23 +852,23 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-
-		// Get schema from the membership endpoint.
-		$schema = $this->invites_endpoint->get_item_schema();
-
-		// Set title to this endpoint.
-		$schema['title'] = 'bp_group_membership_request';
-
-		// Adapt some item schema property descriptions to this endpoint.
-		$schema['properties']['user_id']['description']  = __( 'The ID of the user who requested a Group membership.', 'buddypress' );
-		$schema['properties']['group_id']['description'] = __( 'The ID of the group the user requested a membership for.', 'buddypress' );
-		$schema['properties']['type']['default']         = 'request';
-
-		// Remove unused properties.
-		unset( $schema['properties']['invite_sent'], $schema['properties']['inviter_id'] );
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
+
+			// Get schema from the membership endpoint.
+			$schema = $this->invites_endpoint->get_item_schema();
+
+			// Set title to this endpoint.
+			$schema['title'] = 'bp_group_membership_request';
+
+			// Adapt some item schema property descriptions to this endpoint.
+			$schema['properties']['user_id']['description']  = __( 'The ID of the user who requested a Group membership.', 'buddypress' );
+			$schema['properties']['group_id']['description'] = __( 'The ID of the group the user requested a membership for.', 'buddypress' );
+			$schema['properties']['type']['default']         = 'request';
+
+			// Remove unused properties.
+			unset( $schema['properties']['invite_sent'], $schema['properties']['inviter_id'] );
+
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1291,12 +1291,17 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// (Re)cache current schema here.
+		if ( ( bp_disable_group_avatar_uploads() && $this->schema ) || is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the group schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_group_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_group_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1118,178 +1118,177 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_groups',
-			'type'       => 'object',
-			'properties' => array(
-				'id'                 => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the Group.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'creator_id'         => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user who created the Group.', 'buddypress' ),
-					'type'        => 'integer',
-					'default'     => bp_loggedin_user_id(),
-				),
-				'name'               => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The name of the Group.', 'buddypress' ),
-					'type'        => 'string',
-					'required'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
+		if ( is_null( $this->schema ) ) {
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_groups',
+				'type'       => 'object',
+				'properties' => array(
+					'id'                 => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the Group.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'creator_id'         => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the user who created the Group.', 'buddypress' ),
+						'type'        => 'integer',
+						'default'     => bp_loggedin_user_id(),
+					),
+					'name'               => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The name of the Group.', 'buddypress' ),
+						'type'        => 'string',
+						'required'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+					'slug'               => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The URL-friendly slug for the Group.', 'buddypress' ),
+						'type'        => 'string',
+						'arg_options' => array(
+							'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+						),
+					),
+					'link'               => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The permalink to the Group on the site.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+					'description'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The description of the Group.', 'buddypress' ),
+						'type'        => 'object',
+						'required'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+							'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the description of the Group, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the description of the Group, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'status'             => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The status of the Group.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => buddypress()->groups->valid_status,
+						'default'     => 'public',
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_key',
+						),
+					),
+					'enable_forum'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the Group has a forum enabled or not.', 'buddypress' ),
+						'type'        => 'boolean',
+					),
+					'parent_id'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'ID of the parent Group.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'date_created'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date the Group was created, in the site's timezone.", 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+					'types'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The type(s) of the Group.', 'buddypress' ),
+						'readonly'    => true,
+						'enum'        => bp_groups_get_group_types(),
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'string',
+						),
+					),
+					'admins'             => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'Group administrators.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'object',
+						),
+					),
+					'mods'               => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'Group moderators.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'object',
+						),
+					),
+					'total_member_count' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Count of all Group members.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'last_activity'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date the Group was last active, in the site's timezone.", 'buddypress' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'format'      => 'date-time',
+					),
+					'last_activity_diff'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The human diff time the Group was last active, in the site's timezone.", 'buddypress' ),
+						'type'        => 'string',
+						'readonly'    => true,
 					),
 				),
-				'slug'               => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The URL-friendly slug for the Group.', 'buddypress' ),
-					'type'        => 'string',
-					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-					),
-				),
-				'link'               => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The permalink to the Group on the site.', 'buddypress' ),
+			);
+
+			if ( true !== bp_disable_group_avatar_uploads() ) {
+				$avatar_properties = array();
+
+				$avatar_properties['full'] = array(
+					/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'description'        => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The description of the Group.', 'buddypress' ),
+				);
+
+				$avatar_properties['thumb'] = array(
+					/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+				);
+
+				$schema['properties']['avatar_urls'] = array(
+					'description' => __( 'Avatar URLs for the group.', 'buddypress' ),
 					'type'        => 'object',
-					'required'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the description of the Group, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the description of the Group, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-				'status'             => array(
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The status of the Group.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => buddypress()->groups->valid_status,
-					'default'     => 'public',
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
-				'enable_forum'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the Group has a forum enabled or not.', 'buddypress' ),
-					'type'        => 'boolean',
-				),
-				'parent_id'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'ID of the parent Group.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'date_created'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date the Group was created, in the site's timezone.", 'buddypress' ),
 					'readonly'    => true,
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-				'types'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The type(s) of the Group.', 'buddypress' ),
-					'readonly'    => true,
-					'enum'        => bp_groups_get_group_types(),
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'string',
-					),
-				),
-				'admins'             => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'Group administrators.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'object',
-					),
-				),
-				'mods'               => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'Group moderators.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'object',
-					),
-				),
-				'total_member_count' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Count of all Group members.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'last_activity'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date the Group was last active, in the site's timezone.", 'buddypress' ),
-					'type'        => 'string',
-					'readonly'    => true,
-					'format'      => 'date-time',
-				),
-				'last_activity_diff'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The human diff time the Group was last active, in the site's timezone.", 'buddypress' ),
-					'type'        => 'string',
-					'readonly'    => true,
-				),
-			),
-		);
+					'properties'  => $avatar_properties,
+				);
+			}
 
-		// Avatars.
-		if ( true !== bp_disable_group_avatar_uploads() ) {
-			$avatar_properties = array();
-
-			$avatar_properties['full'] = array(
-				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'view', 'edit' ),
-			);
-
-			$avatar_properties['thumb'] = array(
-				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'view', 'edit' ),
-			);
-
-			$schema['properties']['avatar_urls'] = array(
-				'description' => __( 'Avatar URLs for the group.', 'buddypress' ),
-				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'properties'  => $avatar_properties,
-			);
-		}
-
-		// Cache current schema here.
-		if ( is_null( $this->schema ) ) {
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -737,11 +737,8 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'last_activity_diff' => null,
 		);
 
-		// Get item schema.
-		$schema = $this->get_item_schema();
-
-		// Avatars.
-		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
+		// Return avatars, if allowed.
+		if ( true !== bp_disable_group_avatar_uploads() ) {
 			$data['avatar_urls'] = array(
 				'full'  => bp_core_fetch_avatar(
 					array(
@@ -1263,7 +1260,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 		);
 
 		// Avatars.
-		if ( ! bp_disable_group_avatar_uploads() ) {
+		if ( true !== bp_disable_group_avatar_uploads() ) {
 			$avatar_properties = array();
 
 			$avatar_properties['full'] = array(
@@ -1291,8 +1288,8 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			);
 		}
 
-		// (Re)cache current schema here.
-		if ( ( bp_disable_group_avatar_uploads() && $this->schema ) || is_null( $this->schema ) ) {
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -461,12 +461,17 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
-		 * Filters the member avatar schema.
+		 * Filters the attachments member avatar schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_attachments_member_avatar_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_attachments_member_avatar_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -439,31 +439,28 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_attachments_member_avatar',
-			'type'       => 'object',
-			'properties' => array(
-				'full'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Full size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'thumb' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Thumb size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_attachments_member_avatar',
+				'type'       => 'object',
+				'properties' => array(
+					'full'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Full size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+					'thumb' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Thumb size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
@@ -426,11 +426,16 @@ class BP_REST_Attachments_Member_Cover_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
-		 * Filters the user cover schema.
+		 * Filters the attachment member cover schema.
 		 *
-		 * @param string $schema The endpoint schema.
+		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_attachments_member_cover_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_attachments_member_cover_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 }

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
@@ -411,24 +411,21 @@ class BP_REST_Attachments_Member_Cover_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_attachments_member_cover',
-			'type'       => 'object',
-			'properties' => array(
-				'image' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Full size of the image file.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_attachments_member_cover',
+				'type'       => 'object',
+				'properties' => array(
+					'image' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Full size of the image file.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'readonly'    => true,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -237,7 +237,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				'status' => rest_authorization_required_code(),
 			)
 		);
-		$user   = bp_rest_get_user( $request['id'] );
+
+		$user = bp_rest_get_user( $request['id'] );
 
 		if ( ! $user instanceof WP_User ) {
 			$retval = new WP_Error(
@@ -803,13 +804,13 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				'id'                 => array(
 					'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
 					'type'        => 'integer',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'               => array(
 					'description' => __( 'Display name for the member.', 'buddypress' ),
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -817,7 +818,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				'mention_name'       => array(
 					'description' => __( 'The name used for that user in @-mentions.', 'buddypress' ),
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -827,13 +828,13 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'description' => __( 'Profile URL of the member.', 'buddypress' ),
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'user_login'         => array(
 					'description' => __( 'An alphanumeric identifier for the Member.', 'buddypress' ),
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'required'    => true,
 					'arg_options' => array(
 						'sanitize_callback' => array( $this, 'check_username' ),
@@ -846,7 +847,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'items'       => array(
 						'type' => 'string',
 					),
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'registered_date'    => array(
@@ -962,7 +963,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
-				'context'     => array( 'embed', 'view', 'edit' ),
+				'context'     => array( 'view', 'edit' ),
 			);
 
 			$avatar_properties['thumb'] = array(
@@ -970,16 +971,24 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 				'type'        => 'string',
 				'format'      => 'uri',
-				'context'     => array( 'embed', 'view', 'edit' ),
+				'context'     => array( 'view', 'edit' ),
 			);
 
 			$schema['properties']['avatar_urls'] = array(
 				'description' => __( 'Avatar URLs for the member.', 'buddypress' ),
 				'type'        => 'object',
-				'context'     => array( 'embed', 'view', 'edit' ),
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'properties'  => $avatar_properties,
 			);
+		}
+
+		// Update schema if member types don't match.
+		$update_schema = ( $this->schema && $schema['properties']['member_types']['enum'] !== $this->schema['properties']['member_types']['enum'] );
+
+		// (Re)cache current schema here.
+		if ( $update_schema || is_null( $this->schema ) ) {
+			$this->schema = $schema;
 		}
 
 		/**

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -552,11 +552,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			$data['mention_name'] = bp_activity_get_user_mentionname( $user->ID );
 		}
 
-		// Get item schema.
-		$schema = $this->get_item_schema();
-
 		// Avatars.
-		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
+		if ( true === buddypress()->avatar->show_avatars ) {
 			$data['avatar_urls'] = array(
 				'full'  => bp_core_fetch_avatar(
 					array(

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -983,11 +983,8 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			);
 		}
 
-		// Update schema if member types don't match.
-		$update_schema = ( $this->schema && $schema['properties']['member_types']['enum'] !== $this->schema['properties']['member_types']['enum'] );
-
 		// (Re)cache current schema here.
-		if ( $update_schema || is_null( $this->schema ) ) {
+		if ( is_null( $this->schema ) ) {
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -793,195 +793,194 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_members',
-			'type'       => 'object',
-			'properties' => array(
-				'id'                 => array(
-					'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
-					'type'        => 'integer',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'name'               => array(
-					'description' => __( 'Display name for the member.', 'buddypress' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
+		if ( is_null( $this->schema ) ) {
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_members',
+				'type'       => 'object',
+				'properties' => array(
+					'id'                 => array(
+						'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'name'               => array(
+						'description' => __( 'Display name for the member.', 'buddypress' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+					'mention_name'       => array(
+						'description' => __( 'The name used for that user in @-mentions.', 'buddypress' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'readonly'    => true,
+					),
+					'link'               => array(
+						'description' => __( 'Profile URL of the member.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'uri',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'user_login'         => array(
+						'description' => __( 'An alphanumeric identifier for the Member.', 'buddypress' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'required'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => array( $this, 'check_username' ),
+						),
+					),
+					'member_types'       => array(
+						'description' => __( 'Member types associated with the member.', 'buddypress' ),
+						'enum'        => bp_get_member_types(),
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'string',
+						),
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'registered_date'    => array(
+						'description' => __( 'Registration date for the member.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+					'password'           => array(
+						'description' => __( 'Password for the member (never included).', 'buddypress' ),
+						'type'        => 'string',
+						'context'     => array(), // Password is never displayed.
+						'required'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => array( $this, 'check_user_password' ),
+						),
+					),
+					'roles'              => array(
+						'description' => __( 'Roles assigned to the member.', 'buddypress' ),
+						'type'        => 'array',
+						'context'     => array( 'edit' ),
+						'items'       => array(
+							'type' => 'string',
+						),
+					),
+					'capabilities'       => array(
+						'description' => __( 'All capabilities assigned to the user.', 'buddypress' ),
+						'type'        => 'object',
+						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+					'extra_capabilities' => array(
+						'description' => __( 'Any extra capabilities assigned to the user.', 'buddypress' ),
+						'type'        => 'object',
+						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+					'xprofile'             => array(
+						'description' => __( 'Member XProfile groups and its fields.', 'buddypress' ),
+						'type'        => 'array',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'friendship_status'    => array(
+						'description' => __( 'Friendship relation with, current, logged in user.', 'buddypress' ),
+						'type'        => 'bool',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'friendship_status_slug' => array(
+						'description' => __( 'Slug of the friendship status with current logged in user.', 'buddypress' ),
+						'enum'        => array( 'is_friend', 'not_friends', 'pending', 'awaiting_response' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'last_activity'          => array(
+						'description' => __( 'Last date the member was active on the site.', 'buddypress' ),
+						'type'        => 'object',
+						'properties'  => array(
+							'timediff' => array(
+								'type' => 'string',
+							),
+							'date'     => array(
+								'type'   => 'string',
+								'format' => 'date-time',
+							),
+						),
+						'format'      => 'date-time',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'latest_update'          => array(
+						'description' => __( 'The content of the latest activity posted by the member.', 'buddypress' ),
+						'type'        => 'object',
+						'properties'  => array(
+							'id'       => array(
+								'context'     => array( 'view', 'edit' ),
+								'description' => __( 'A unique numeric ID for the activity.', 'buddypress' ),
+								'readonly'    => true,
+								'type'        => 'integer',
+							),
+							'raw'      => array(
+								'description' => __( 'Content for the activity, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the activity, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+						'readonly'    => true,
+					),
+					'total_friend_count'     => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Total number of friends for the member.', 'buddypress' ),
+						'type'        => 'integer',
+						'readonly'    => true,
 					),
 				),
-				'mention_name'       => array(
-					'description' => __( 'The name used for that user in @-mentions.', 'buddypress' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'readonly'    => true,
-				),
-				'link'               => array(
-					'description' => __( 'Profile URL of the member.', 'buddypress' ),
+			);
+
+			if ( true === buddypress()->avatar->show_avatars ) {
+				$avatar_properties = array();
+
+				$avatar_properties['full'] = array(
+					/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'user_login'         => array(
-					'description' => __( 'An alphanumeric identifier for the Member.', 'buddypress' ),
+				);
+
+				$avatar_properties['thumb'] = array(
+					/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
+					'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'context'     => array( 'view', 'edit' ),
-					'required'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => array( $this, 'check_username' ),
-					),
-				),
-				'member_types'       => array(
-					'description' => __( 'Member types associated with the member.', 'buddypress' ),
-					'enum'        => bp_get_member_types(),
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'string',
-					),
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'registered_date'    => array(
-					'description' => __( 'Registration date for the member.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'date-time',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-				'password'           => array(
-					'description' => __( 'Password for the member (never included).', 'buddypress' ),
-					'type'        => 'string',
-					'context'     => array(), // Password is never displayed.
-					'required'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => array( $this, 'check_user_password' ),
-					),
-				),
-				'roles'              => array(
-					'description' => __( 'Roles assigned to the member.', 'buddypress' ),
-					'type'        => 'array',
-					'context'     => array( 'edit' ),
-					'items'       => array(
-						'type' => 'string',
-					),
-				),
-				'capabilities'       => array(
-					'description' => __( 'All capabilities assigned to the user.', 'buddypress' ),
+				);
+
+				$schema['properties']['avatar_urls'] = array(
+					'description' => __( 'Avatar URLs for the member.', 'buddypress' ),
 					'type'        => 'object',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-				'extra_capabilities' => array(
-					'description' => __( 'Any extra capabilities assigned to the user.', 'buddypress' ),
-					'type'        => 'object',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-				'xprofile'             => array(
-					'description' => __( 'Member XProfile groups and its fields.', 'buddypress' ),
-					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-				),
-				'friendship_status'    => array(
-					'description' => __( 'Friendship relation with, current, logged in user.', 'buddypress' ),
-					'type'        => 'bool',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'friendship_status_slug' => array(
-					'description' => __( 'Slug of the friendship status with current logged in user.', 'buddypress' ),
-					'enum'        => array( 'is_friend', 'not_friends', 'pending', 'awaiting_response' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'last_activity'          => array(
-					'description' => __( 'Last date the member was active on the site.', 'buddypress' ),
-					'type'        => 'object',
-					'properties'  => array(
-						'timediff' => array(
-							'type' => 'string',
-						),
-						'date'     => array(
-							'type'   => 'string',
-							'format' => 'date-time',
-						),
-					),
-					'format'      => 'date-time',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'latest_update'          => array(
-					'description' => __( 'The content of the latest activity posted by the member.', 'buddypress' ),
-					'type'        => 'object',
-					'properties'  => array(
-						'id'       => array(
-							'context'     => array( 'view', 'edit' ),
-							'description' => __( 'A unique numeric ID for the activity.', 'buddypress' ),
-							'readonly'    => true,
-							'type'        => 'integer',
-						),
-						'raw'      => array(
-							'description' => __( 'Content for the activity, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the activity, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-					'readonly'    => true,
-				),
-				'total_friend_count'     => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Total number of friends for the member.', 'buddypress' ),
-					'type'        => 'integer',
-					'readonly'    => true,
-				),
-			),
-		);
+					'properties'  => $avatar_properties,
+				);
+			}
 
-		// Avatars.
-		if ( true === buddypress()->avatar->show_avatars ) {
-			$avatar_properties = array();
-
-			$avatar_properties['full'] = array(
-				/* translators: 1: Full avatar width in pixels. 2: Full avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'view', 'edit' ),
-			);
-
-			$avatar_properties['thumb'] = array(
-				/* translators: 1: Thumb avatar width in pixels. 2: Thumb avatar height in pixels */
-				'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'view', 'edit' ),
-			);
-
-			$schema['properties']['avatar_urls'] = array(
-				'description' => __( 'Avatar URLs for the member.', 'buddypress' ),
-				'type'        => 'object',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'properties'  => $avatar_properties,
-			);
-		}
-
-		// (Re)cache current schema here.
-		if ( is_null( $this->schema ) ) {
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 
@@ -990,7 +989,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_members_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_members_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
@@ -864,115 +864,115 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_signup',
-			'type'       => 'object',
-			'properties' => array(
-				'id'             => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the signup.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'user_login'     => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The username of the user the signup is for.', 'buddypress' ),
-					'required'    => true,
-					'type'        => 'string',
-				),
-				'user_email'     => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'The email for the user the signup is for.', 'buddypress' ),
-					'type'        => 'string',
-					'required'    => true,
-				),
-				'activation_key' => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'Activation key of the signup.', 'buddypress' ),
-					'type'        => 'string',
-					'readonly'    => true,
-				),
-				'registered'     => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The registered date for the user, in the site\'s timezone.', 'buddypress' ),
-					'type'        => 'string',
-					'readonly'    => true,
-					'format'      => 'date-time',
-				),
-				'date_sent'      => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'The date the activation email was sent to the user, in the site\'s timezone.', 'buddypress' ),
-					'type'        => 'string',
-					'readonly'    => true,
-					'format'      => 'date-time',
-				),
-				'count_sent'     => array(
-					'description' => __( 'The number of times the activation email was sent to the user.', 'buddypress' ),
-					'type'        => 'integer',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-				'meta'           => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'The signup meta information', 'buddypress' ),
-					'type'        => 'object',
-					'properties'  => array(
-						'password' => array(
-							'description' => __( 'Password for the new user (never included).', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array(), // Password is never displayed.
+		if ( is_null( $this->schema ) ) {
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_signup',
+				'type'       => 'object',
+				'properties' => array(
+					'id'             => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the signup.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'user_login'     => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The username of the user the signup is for.', 'buddypress' ),
+						'required'    => true,
+						'type'        => 'string',
+					),
+					'user_email'     => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'The email for the user the signup is for.', 'buddypress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'activation_key' => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'Activation key of the signup.', 'buddypress' ),
+						'type'        => 'string',
+						'readonly'    => true,
+					),
+					'registered'     => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The registered date for the user, in the site\'s timezone.', 'buddypress' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'format'      => 'date-time',
+					),
+					'date_sent'      => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'The date the activation email was sent to the user, in the site\'s timezone.', 'buddypress' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'format'      => 'date-time',
+					),
+					'count_sent'     => array(
+						'description' => __( 'The number of times the activation email was sent to the user.', 'buddypress' ),
+						'type'        => 'integer',
+						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+					'meta'           => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'The signup meta information', 'buddypress' ),
+						'type'        => 'object',
+						'properties'  => array(
+							'password' => array(
+								'description' => __( 'Password for the new user (never included).', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array(), // Password is never displayed.
+							),
 						),
 					),
 				),
-			),
-		);
-
-		if ( bp_is_active( 'xprofile' ) ) {
-			$schema['properties']['user_name'] = array(
-				'context'     => array( 'view', 'edit' ),
-				'description' => __( 'The new user\'s full name.', 'buddypress' ),
-				'type'        => 'string',
-				'required'    => true,
-				'arg_options' => array(
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-			);
-		}
-
-		if ( is_multisite() && $this->is_blog_signup_allowed() ) {
-			$schema['properties']['site_name'] = array(
-				'context'     => array( 'edit' ),
-				'description' => __( 'Unique site name (slug) of the new user\'s child site.', 'buddypress' ),
-				'type'        => 'string',
-				'default'     => '',
 			);
 
-			$schema['properties']['site_title'] = array(
-				'context'     => array( 'edit' ),
-				'description' => __( 'Title of the new user\'s child site.', 'buddypress' ),
-				'type'        => 'string',
-				'default'     => '',
-			);
+			if ( bp_is_active( 'xprofile' ) ) {
+				$schema['properties']['user_name'] = array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'The new user\'s full name.', 'buddypress' ),
+					'type'        => 'string',
+					'required'    => true,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				);
+			}
 
-			$schema['properties']['site_public'] = array(
-				'context'     => array( 'edit' ),
-				'description' => __( 'Search engine visibility of the new user\'s  site.', 'buddypress' ),
-				'type'        => 'boolean',
-				'default'     => true,
-			);
+			if ( is_multisite() && $this->is_blog_signup_allowed() ) {
+				$schema['properties']['site_name'] = array(
+					'context'     => array( 'edit' ),
+					'description' => __( 'Unique site name (slug) of the new user\'s child site.', 'buddypress' ),
+					'type'        => 'string',
+					'default'     => '',
+				);
 
-			$schema['properties']['site_language'] = array(
-				'context'     => array( 'edit' ),
-				'description' => __( 'Language to use for the new user\'s  site.', 'buddypress' ),
-				'type'        => 'string',
-				'default'     => get_locale(),
-				'enum'        => array_merge( array( get_locale() ), $this->get_available_languages() ),
-			);
-		}
+				$schema['properties']['site_title'] = array(
+					'context'     => array( 'edit' ),
+					'description' => __( 'Title of the new user\'s child site.', 'buddypress' ),
+					'type'        => 'string',
+					'default'     => '',
+				);
 
-		// Cache current schema here.
-		if ( is_null( $this->schema ) ) {
+				$schema['properties']['site_public'] = array(
+					'context'     => array( 'edit' ),
+					'description' => __( 'Search engine visibility of the new user\'s  site.', 'buddypress' ),
+					'type'        => 'boolean',
+					'default'     => true,
+				);
+
+				$schema['properties']['site_language'] = array(
+					'context'     => array( 'edit' ),
+					'description' => __( 'Language to use for the new user\'s  site.', 'buddypress' ),
+					'type'        => 'string',
+					'default'     => get_locale(),
+					'enum'        => array_merge( array( get_locale() ), $this->get_available_languages() ),
+				);
+			}
+
+			// Cache current schema here.
 			$this->schema = $schema;
 		}
 

--- a/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
@@ -971,12 +971,17 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the signup schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_signup_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_signup_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -1241,6 +1241,11 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the message schema.
 		 *
@@ -1248,7 +1253,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_message_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_message_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -1098,152 +1098,149 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_messages',
-			'type'       => 'object',
-			'properties' => array(
-				'id'                  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the Thread.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'message_id'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the latest message of the Thread.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'last_sender_id'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of latest sender of the Thread.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'subject'             => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Title of the latest message of the Thread.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Title of the latest message of the Thread, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-							'default'     => false,
-						),
-						'rendered' => array(
-							'description' => __( 'Title of the latest message of the Thread, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'default'     => false,
-						),
-					),
-				),
-				'excerpt'             => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Summary of the latest message of the Thread.', 'buddypress' ),
-					'type'        => 'object',
-					'readonly'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Summary for the latest message of the Thread, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML summary for the latest message of the Thread, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-					),
-				),
-				'message'             => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Content of the latest message of the Thread.', 'buddypress' ),
-					'type'        => 'object',
-					'required'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the latest message of the Thread, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the latest message of the Thread, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-				'date'                => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date the latest message of the Thread, in the site's timezone.", 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-				'unread_count'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Total count of unread messages into the Thread for the requested user.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'sender_ids'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The list of user IDs for all messages in the Thread.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'integer',
-					),
-				),
-				'recipients'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The list of recipient User Objects involved into the Thread.', 'buddypress' ),
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'object',
-					),
-				),
-				'messages'            => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'List of message objects for the thread.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'object',
-					),
-				),
-				'starred_message_ids' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'List of starred message IDs.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'integer',
-					),
-					'default'     => array(),
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_messages',
+				'type'       => 'object',
+				'properties' => array(
+					'id'                  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the Thread.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'message_id'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the latest message of the Thread.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'last_sender_id'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of latest sender of the Thread.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'subject'             => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Title of the latest message of the Thread.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Title of the latest message of the Thread, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+								'default'     => false,
+							),
+							'rendered' => array(
+								'description' => __( 'Title of the latest message of the Thread, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'default'     => false,
+							),
+						),
+					),
+					'excerpt'             => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Summary of the latest message of the Thread.', 'buddypress' ),
+						'type'        => 'object',
+						'readonly'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Summary for the latest message of the Thread, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML summary for the latest message of the Thread, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+					'message'             => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Content of the latest message of the Thread.', 'buddypress' ),
+						'type'        => 'object',
+						'required'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the latest message of the Thread, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the latest message of the Thread, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'date'                => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date the latest message of the Thread, in the site's timezone.", 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+					'unread_count'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Total count of unread messages into the Thread for the requested user.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'sender_ids'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The list of user IDs for all messages in the Thread.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'integer',
+						),
+					),
+					'recipients'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The list of recipient User Objects involved into the Thread.', 'buddypress' ),
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'object',
+						),
+					),
+					'messages'            => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'List of message objects for the thread.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'object',
+						),
+					),
+					'starred_message_ids' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'List of starred message IDs.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'integer',
+						),
+						'default'     => array(),
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -805,12 +805,17 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
-		 * Filters the notifications schema.
+		 * Filters the notification schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_notification_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_notification_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -753,61 +753,58 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_notifications',
-			'type'       => 'object',
-			'properties' => array(
-				'id'                => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the notification.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'user_id'           => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user the notification is addressed to.', 'buddypress' ),
-					'type'        => 'integer',
-					'default'     => bp_loggedin_user_id(),
-				),
-				'item_id'           => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the item associated with the notification.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'secondary_item_id' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the secondary item associated with the notification.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'component'         => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The name of the BuddyPress component the notification relates to.', 'buddypress' ),
-					'type'        => 'string',
-				),
-				'action'            => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The name of the component\'s action the notification is about.', 'buddypress' ),
-					'type'        => 'string',
-				),
-				'date'              => array(
-					'description' => __( 'The date the notification was created, in the site\'s timezone.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'date-time',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'is_new'            => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether it\'s a new notification or not.', 'buddypress' ),
-					'type'        => 'integer',
-					'default'     => 1,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_notifications',
+				'type'       => 'object',
+				'properties' => array(
+					'id'                => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the notification.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'user_id'           => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the user the notification is addressed to.', 'buddypress' ),
+						'type'        => 'integer',
+						'default'     => bp_loggedin_user_id(),
+					),
+					'item_id'           => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the item associated with the notification.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'secondary_item_id' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the secondary item associated with the notification.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'component'         => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The name of the BuddyPress component the notification relates to.', 'buddypress' ),
+						'type'        => 'string',
+					),
+					'action'            => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The name of the component\'s action the notification is about.', 'buddypress' ),
+						'type'        => 'string',
+					),
+					'date'              => array(
+						'description' => __( 'The date the notification was created, in the site\'s timezone.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+						'context'     => array( 'view', 'edit' ),
+					),
+					'is_new'            => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether it\'s a new notification or not.', 'buddypress' ),
+						'type'        => 'integer',
+						'default'     => 1,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -526,72 +526,69 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_xprofile_data',
-			'type'       => 'object',
-			'properties' => array(
-				'id'           => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the profile data.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'field_id'     => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the field the data is from.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'user_id'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the user the field data is from.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'value'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The value of the field data.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
-					),
-					'properties'  => array(
-						'raw'          => array(
-							'description' => __( 'Value for the field, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'unserialized' => array(
-							'description' => __( 'Unserialized value for the field, regular string will be casted as array.', 'buddypress' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'items'       => array(
-								'type' => 'string',
-							),
-							'readonly'    => true,
-						),
-						'rendered'     => array(
-							'description' => __( 'HTML value for the field, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-				'last_updated' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The date the field data was last updated, in the site\'s timezone.', 'buddypress' ),
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_xprofile_data',
+				'type'       => 'object',
+				'properties' => array(
+					'id'           => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the profile data.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'field_id'     => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the field the data is from.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'user_id'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the user the field data is from.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'value'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The value of the field data.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
+						),
+						'properties'  => array(
+							'raw'          => array(
+								'description' => __( 'Value for the field, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'unserialized' => array(
+								'description' => __( 'Unserialized value for the field, regular string will be casted as array.', 'buddypress' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type' => 'string',
+								),
+								'readonly'    => true,
+							),
+							'rendered'     => array(
+								'description' => __( 'HTML value for the field, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'last_updated' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The date the field data was last updated, in the site\'s timezone.', 'buddypress' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -589,11 +589,16 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the xprofile data schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_xprofile_data_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_xprofile_data_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 }

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -775,12 +775,17 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the xprofile field group schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_xprofile_field_group_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_xprofile_field_group_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -714,70 +714,67 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_xprofile_group',
-			'type'       => 'object',
-			'properties' => array(
-				'id'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the group of profile fields.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'name'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The name of group of profile fields.', 'buddypress' ),
-					'type'        => 'string',
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-				'description' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The description of the group of profile fields.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the group of profile fields, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the group of profile fields, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-				'group_order' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The order of the group of profile fields.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'can_delete'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the group of profile fields can be deleted or not.', 'buddypress' ),
-					'type'        => 'boolean',
-					'readonly'    => true,
-				),
-				'fields'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The fields associated with this group of profile fields.', 'buddypress' ),
-					'type'        => 'array',
-					'readonly'    => true,
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_xprofile_group',
+				'type'       => 'object',
+				'properties' => array(
+					'id'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the group of profile fields.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'name'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The name of group of profile fields.', 'buddypress' ),
+						'type'        => 'string',
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+					'description' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The description of the group of profile fields.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+							'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the group of profile fields, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the group of profile fields, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'group_order' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The order of the group of profile fields.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'can_delete'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the group of profile fields can be deleted or not.', 'buddypress' ),
+						'type'        => 'boolean',
+						'readonly'    => true,
+					),
+					'fields'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The fields associated with this group of profile fields.', 'buddypress' ),
+						'type'        => 'array',
+						'readonly'    => true,
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -957,143 +957,140 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_xprofile_field',
-			'type'       => 'object',
-			'properties' => array(
-				'id'                => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the profile field.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'integer',
-				),
-				'group_id'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the group the field is part of.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'parent_id'         => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The ID of the parent field.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'type'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The type for the profile field.', 'buddypress' ),
-					'type'        => 'string',
-					'enum'        => buddypress()->profile->field_types,
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
-				'name'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The name of the profile field.', 'buddypress' ),
-					'type'        => 'string',
-					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-				'description'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The description of the profile field.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
-						'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the profile field, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the profile field, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-				'is_required'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the profile field must have a value.', 'buddypress' ),
-					'type'        => 'boolean',
-				),
-				'can_delete'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the profile field can be deleted or not.', 'buddypress' ),
-					'default'     => true,
-					'type'        => 'boolean',
-				),
-				'field_order'       => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The order of the profile field into the group of fields.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'option_order'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The order of the option into the profile field list of options', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'order_by'          => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The way profile field\'s options are ordered.', 'buddypress' ),
-					'default'     => 'asc',
-					'type'        => 'string',
-					'enum'        => array( 'asc', 'desc' ),
-				),
-				'is_default_option' => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Whether the option is the default one for the profile field.', 'buddypress' ),
-					'type'        => 'boolean',
-				),
-				'visibility_level'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Who may see the saved value for this profile field.', 'buddypress' ),
-					'default'     => 'public',
-					'type'        => 'string',
-					'enum'        => array_keys( bp_xprofile_get_visibility_levels() ),
-				),
-				'options'  => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Options of the profile field.', 'buddypress' ),
-					'type'        => 'array',
-					'readonly'    => true,
-				),
-				'data'              => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'The saved value for this profile field.', 'buddypress' ),
-					'type'        => 'object',
-					'readonly'    => true,
-					'properties'  => array(
-						'raw'          => array(
-							'description' => __( 'Value for the field, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'unserialized' => array(
-							'description' => __( 'Unserialized value for the field, regular string will be casted as array.', 'buddypress' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'rendered'     => array(
-							'description' => __( 'HTML value for the field, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-					),
-				),
-			),
-		);
-
-		// Cache current schema here.
 		if ( is_null( $this->schema ) ) {
-			$this->schema = $schema;
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_xprofile_field',
+				'type'       => 'object',
+				'properties' => array(
+					'id'                => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the profile field.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'integer',
+					),
+					'group_id'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the group the field is part of.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'parent_id'         => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The ID of the parent field.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'type'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The type for the profile field.', 'buddypress' ),
+						'type'        => 'string',
+						'enum'        => buddypress()->profile->field_types,
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_key',
+						),
+					),
+					'name'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The name of the profile field.', 'buddypress' ),
+						'type'        => 'string',
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+					'description'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The description of the profile field.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+							'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the profile field, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the profile field, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'is_required'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the profile field must have a value.', 'buddypress' ),
+						'type'        => 'boolean',
+					),
+					'can_delete'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the profile field can be deleted or not.', 'buddypress' ),
+						'default'     => true,
+						'type'        => 'boolean',
+					),
+					'field_order'       => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The order of the profile field into the group of fields.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'option_order'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The order of the option into the profile field list of options', 'buddypress' ),
+						'type'        => 'integer',
+					),
+					'order_by'          => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The way profile field\'s options are ordered.', 'buddypress' ),
+						'default'     => 'asc',
+						'type'        => 'string',
+						'enum'        => array( 'asc', 'desc' ),
+					),
+					'is_default_option' => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Whether the option is the default one for the profile field.', 'buddypress' ),
+						'type'        => 'boolean',
+					),
+					'visibility_level'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Who may see the saved value for this profile field.', 'buddypress' ),
+						'default'     => 'public',
+						'type'        => 'string',
+						'enum'        => array_keys( bp_xprofile_get_visibility_levels() ),
+					),
+					'options'  => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Options of the profile field.', 'buddypress' ),
+						'type'        => 'array',
+						'readonly'    => true,
+					),
+					'data'              => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'The saved value for this profile field.', 'buddypress' ),
+						'type'        => 'object',
+						'readonly'    => true,
+						'properties'  => array(
+							'raw'          => array(
+								'description' => __( 'Value for the field, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'unserialized' => array(
+								'description' => __( 'Unserialized value for the field, regular string will be casted as array.', 'buddypress' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'rendered'     => array(
+								'description' => __( 'HTML value for the field, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			);
 		}
 
 		/**

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -1091,12 +1091,17 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			),
 		);
 
+		// Cache current schema here.
+		if ( is_null( $this->schema ) ) {
+			$this->schema = $schema;
+		}
+
 		/**
 		 * Filters the xprofile field schema.
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_xprofile_field_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_xprofile_field_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,8 +93,9 @@
 			}
 		},
 		"@wordpress/env": {
-			"version": "https://gitpkg.now.sh/WordPress/gutenberg/packages/env?trunk",
-			"integrity": "sha512-MugKemOw3+cfe4afwp1qZcNjj0BK7QVm8bAeP0bToHZLc8/Z0T4Ofr2uWgoipcXWAEgmKgv62G/jMX2IL4aQjw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.0.0.tgz",
+			"integrity": "sha512-e/86uoT15PigMGEOyblLQX1/CzR+ruNxuzy6iCTFmcw0VllNHFJteOWJjd9MVo8AhhDg89KK2sTQ8GmM3lXSLw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
@@ -237,9 +238,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
-			"integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+			"integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
 			"dev": true
 		},
 		"cli-width": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "plugin"
   ],
   "devDependencies": {
-    "@wordpress/env": "https://gitpkg.now.sh/WordPress/gutenberg/packages/env?trunk"
+    "@wordpress/env": "^4.0.0"
   },
   "engines": {
     "node": ">=14.15.0",
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "wp-env": "wp-env",
-    "phpunit": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/BP-REST/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/BP-REST/phpunit.xml.dist'",
+    "phpunit": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/bp-rest/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/bp-rest/phpunit.xml.dist'",
     "phpunit:mu": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/BP-REST/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/BP-REST/tests/multisite.xml'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "wp-env": "wp-env",
-    "phpunit": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/bp-rest/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/bp-rest/phpunit.xml.dist'",
+    "phpunit": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/BP-REST/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/BP-REST/phpunit.xml.dist'",
     "phpunit:mu": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/BP-REST/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/BP-REST/tests/multisite.xml'"
   }
 }

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -1073,7 +1073,6 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_update_item_invalid_id() {
 		$this->bp->set_current_user( $this->user );
-		$a = $this->bp_factory->activity->create();
 
 		$request  = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$request->add_header( 'content-type', 'application/json' );

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -742,6 +742,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * @group get_item
 	 * @group item_schema
 	 */
 	public function test_get_item_schema_member_types_enum() {
@@ -750,6 +751,12 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		foreach ( $expected as $type ) {
 			bp_register_member_type( $type );
 		}
+
+		// Re-initialize the controller to cache-bust schemas from prior test runs.
+		$GLOBALS['wp_rest_server']->override_by_default = true;
+		$controller                                     = new BP_REST_Members_Endpoint();
+		$controller->register_routes();
+		$GLOBALS['wp_rest_server']->override_by_default = false;
 
 		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint_url );
 		$response   = $this->server->dispatch( $request );

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -309,6 +309,31 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * @group get_item
+	 * @group avatar
+	 */
+	public function test_get_item_without_avatar() {
+		$u = $this->factory->user->create();
+
+		// Register and set member types.
+		bp_register_member_type( 'foo' );
+		bp_register_member_type( 'bar' );
+		bp_set_member_type( $u, 'foo' );
+		bp_set_member_type( $u, 'bar', true );
+
+		buddypress()->avatar->show_avatars = false;
+
+		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $u ) );
+		$response = $this->server->dispatch( $request );
+
+		buddypress()->avatar->show_avatars = true;
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertArrayNotHasKey( 'avatar_urls', $response->get_data() );
+	}
+
+	/**
+	 * @group get_item
 	 */
 	public function test_get_item_invalid_id() {
 		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
@@ -321,6 +346,11 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group create_item
 	 */
 	public function test_create_item() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->allow_user_to_manage_multisite();
 
 		$params = array(
@@ -449,6 +479,11 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group update_item
 	 */
 	public function test_update_item_types() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$u = $this->factory->user->create( array(
 			'email' => 'member@type.com',
 			'name'  => 'User Name',
@@ -520,6 +555,11 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group delete_item
 	 */
 	public function test_delete_item() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$u = $this->factory->user->create( array( 'display_name' => 'Deleted User' ) );
 
 		$this->allow_user_to_manage_multisite();
@@ -706,7 +746,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 
 		// Single.
 		$request  = new WP_REST_Request( 'OPTIONS', sprintf( $this->endpoint_url . '/%d', self::$user ) );
@@ -714,7 +754,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function update_additional_field( $value, $data, $attribute ) {
@@ -729,6 +769,11 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group additional_fields
 	 */
 	public function test_additional_fields() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$registered_fields = $GLOBALS['wp_rest_additional_fields'];
 
 		bp_rest_register_field( 'members', 'foo_field', array(

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -334,6 +334,29 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 	/**
 	 * @group get_item
+	 * @group avatar
+	 */
+	function test_get_item_schema_show_avatar() {
+		buddypress()->avatar->show_avatars = false;
+
+		// Re-initialize the controller to cache-bust schemas from prior test runs.
+		$GLOBALS['wp_rest_server']->override_by_default = true;
+		$controller                                     = new BP_REST_Members_Endpoint();
+		$controller->register_routes();
+		$GLOBALS['wp_rest_server']->override_by_default = false;
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint_url );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		buddypress()->avatar->show_avatars = true;
+
+		$this->assertArrayNotHasKey( 'avatar_urls', $properties );
+	}
+
+	/**
+	 * @group get_item
 	 */
 	public function test_get_item_invalid_id() {
 		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
@@ -499,11 +522,9 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		) );
 
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
-		$member_type = reset( $data['member_types'] );
-
-		$this->assertSame( 'membertypeone', $member_type );
+		$this->assertSame( 'membertypeone', reset( $data['member_types'] ) );
 	}
 
 	/**

--- a/tests/membership/test-group-membership-controller.php
+++ b/tests/membership/test-group-membership-controller.php
@@ -970,6 +970,11 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 	}
 
 	public function test_get_item_schema() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint_url . $this->group_id . '/members' );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
@@ -1008,6 +1013,6 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 }

--- a/tests/multisite.xml
+++ b/tests/multisite.xml
@@ -11,8 +11,7 @@
 	</php>
 	<testsuites>
 		<testsuite name="unit">
-			<directory prefix="test-" suffix=".php">./blogs/</directory>
-			<directory prefix="test-" suffix=".php">./attachments/</directory>
+			<directory prefix="test-" suffix=".php">./</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/signup/test-controller.php
+++ b/tests/signup/test-controller.php
@@ -73,6 +73,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group get_items
 	 */
 	public function test_get_items() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->bp->set_current_user( $this->user );
 
 		$s1     = $this->create_signup();
@@ -97,6 +102,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group get_items
 	 */
 	public function test_get_paginated_items() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->bp->set_current_user( $this->user );
 
 		$s1 = $this->create_signup();
@@ -153,6 +163,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group get_item
 	 */
 	public function test_get_item() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->bp->set_current_user( $this->user );
 
 		$signup = $this->endpoint->get_signup_object( $this->signup_id );
@@ -173,6 +188,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group get_item
 	 */
 	public function test_get_item_invalid_signup_id() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->bp->set_current_user( $this->user );
 
 		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
@@ -274,6 +294,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group delete_item
 	 */
 	public function test_delete_item() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->bp->set_current_user( $this->user );
 
 		$signup = $this->endpoint->get_signup_object( $this->signup_id );
@@ -300,7 +325,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'bp_rest_invalid_id', $response, 404 );
+		if ( is_multisite() ) {
+			$this->assertErrorResponse( 'bp_rest_authorization_required', $response, 403 );
+		} else {
+			$this->assertErrorResponse( 'bp_rest_invalid_id', $response, 404 );
+		}
 	}
 
 	/**
@@ -329,6 +358,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_prepare_item() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$this->bp->set_current_user( $this->user );
 
 		$signup = $this->endpoint->get_signup_object( $this->signup_id );
@@ -385,6 +419,11 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_schema() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
 		$request    = new WP_REST_Request( 'OPTIONS', sprintf( $this->endpoint_url . '/%d', $this->signup_id ) );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
@@ -397,6 +436,36 @@ class BP_Test_REST_Signup_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'registered', $properties );
 		$this->assertArrayHasKey( 'activation_key', $properties );
 		$this->assertArrayHasKey( 'user_email', $properties );
+		$this->assertArrayHasKey( 'date_sent', $properties );
+		$this->assertArrayHasKey( 'count_sent', $properties );
+		$this->assertArrayHasKey( 'meta', $properties );
+	}
+
+	public function test_get_item_multisite_schema() {
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped();
+		}
+
+		$request    = new WP_REST_Request( 'OPTIONS', sprintf( $this->endpoint_url . '/%d', $this->signup_id ) );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 13, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'user_login', $properties );
+		$this->assertArrayHasKey( 'user_name', $properties );
+		$this->assertArrayHasKey( 'registered', $properties );
+		$this->assertArrayHasKey( 'activation_key', $properties );
+		$this->assertArrayHasKey( 'user_email', $properties );
+		$this->assertArrayHasKey( 'date_sent', $properties );
+		$this->assertArrayHasKey( 'count_sent', $properties );
+		$this->assertArrayHasKey( 'meta', $properties );
+		$this->assertArrayHasKey( 'site_language', $properties );
+		$this->assertArrayHasKey( 'site_public', $properties );
+		$this->assertArrayHasKey( 'site_title', $properties );
+		$this->assertArrayHasKey( 'site_name', $properties );
 	}
 
 	public function test_context_param() {


### PR DESCRIPTION
fixes #225 

- Cache schema from REST controllers
- Update schema cache hook param
-  Unit tests are running on all endpoints on multisite
- Skipped some tests on multisite (they require more investigation)
- Removing the `embed` context for consistency
- Added unit test for a member without an avatar
- updated `@wordpress/env` from its temporary url to the latest version: 4.0