### PR TITLE
Reviewing Components Prepare Links

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1123,11 +1123,32 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			);
 		}
 
+		// Embed Group.
 		if ( bp_is_active( 'groups' ) && 'groups' === $activity->component && ! empty( $activity->item_id ) ) {
-			$group = groups_get_group( $activity->item_id );
-
 			$links['group'] = array(
-				'href'       => bp_get_group_permalink( $group ),
+				'href'       => rest_url(
+					sprintf(
+						'/%s/%s/%d',
+						$this->namespace,
+						buddypress()->groups->id,
+						absint( $activity->item_id )
+					)
+				),
+				'embeddable' => true,
+			);
+		}
+
+		// Embed Blog.
+		if ( bp_is_active( 'blogs' ) && 'blogs' === $activity->component && ! empty( $activity->item_id ) ) {
+			$links['blog'] = array(
+				'href'       => rest_url(
+					sprintf(
+						'/%s/%s/%d',
+						$this->namespace,
+						buddypress()->blogs->id,
+						absint( $activity->item_id )
+					)
+				),
 				'embeddable' => true,
 			);
 		}

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -422,6 +422,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 						'type'          => 'thumb',
 						'blog_id'       => $blog->blog_id,
 						'admin_user_id' => $blog->admin_user_id,
+						'html'          => false,
 					)
 				),
 				'full'  => bp_get_blog_avatar(
@@ -429,6 +430,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 						'type'          => 'full',
 						'blog_id'       => $blog->blog_id,
 						'admin_user_id' => $blog->admin_user_id,
+						'html'          => false,
 					)
 				),
 			);
@@ -473,7 +475,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'user'       => array(
+			'admin'      => array(
 				'href'       => rest_url( bp_rest_get_user_url( $blog->admin_user_id ) ),
 				'embeddable' => true,
 			),
@@ -624,19 +626,19 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 				'type'       => 'object',
 				'properties' => array(
 					'id'            => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'A unique numeric ID for the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
 					'user_id'       => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'A unique numeric ID for the blog admin.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
 					'name'          => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The name of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
@@ -645,32 +647,32 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 						),
 					),
 					'permalink'     => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The permalink of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 						'format'      => 'uri',
 					),
 					'description'   => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The description of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 					),
 					'path'          => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The path of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 					),
 					'domain'        => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'the domain of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 					),
 					'last_activity' => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( "The last activity date from the blog, in the site's timezone.", 'buddypress' ),
 						'type'        => 'string',
 						'format'      => 'date-time',
@@ -686,7 +688,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 					'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				);
 
 				$avatar_properties['thumb'] = array(
@@ -694,13 +696,13 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 					'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				);
 
 				$schema['properties']['avatar_urls'] = array(
 					'description' => __( 'Avatar URLs for the blog.', 'buddypress' ),
 					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 					'properties'  => $avatar_properties,
 				);

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -475,7 +475,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'admin'      => array(
+			'user'      => array(
 				'href'       => rest_url( bp_rest_get_user_url( $blog->admin_user_id ) ),
 				'embeddable' => true,
 			),

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -120,9 +120,8 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$group = $this->groups_endpoint->get_group_object( $request['group_id'] );
-
-		$args = array(
+		$group = $this->groups_endpoint->get_group_object( $request->get_param( 'group_id' ) );
+		$args  = array(
 			'group_id'            => $group->id,
 			'group_role'          => $request['roles'],
 			'type'                => $request['status'],
@@ -699,14 +698,16 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $group_member, $request ) {
-		$user        = bp_rest_get_user( $group_member->user_id );
-		$context     = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$member_data = $this->members_endpoint->user_data( $user, $context, $request );
+		$user                   = bp_rest_get_user( $group_member->user_id );
+		$context                = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$member_data            = $this->members_endpoint->user_data( $user, $context, $request );
+		$group_member->group_id = $request->get_param( 'group_id' );
 
 		// Merge both info.
 		$data = array_merge(
 			$member_data,
 			array(
+				'group'         => (int) $group_member->group_id,
 				'is_mod'        => (bool) $group_member->is_mod,
 				'is_admin'      => (bool) $group_member->is_admin,
 				'is_banned'     => (bool) $group_member->is_banned,
@@ -719,7 +720,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $user ) );
+		$response->add_links( $this->prepare_links( $group_member ) );
 
 		/**
 		 * Filter a group member value returned from the API.
@@ -738,20 +739,23 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param WP_User $user User object.
+	 * @param BP_Groups_Member $group_member Group member object.
 	 * @return array
 	 */
-	protected function prepare_links( $user ) {
-		$base = sprintf( '/%s/%s/', $this->namespace, $this->rest_base );
-		$url  = $base . $user->ID;
+	protected function prepare_links( $group_member ) {
+		$base = sprintf( '/%s/%s', $this->namespace, $this->rest_base );
 
 		// Entity meta.
 		$links = array(
 			'self'       => array(
-				'href' => rest_url( $url ),
+				'href' => rest_url( bp_rest_get_user_url( $group_member->user_id ) ),
 			),
 			'collection' => array(
-				'href' => rest_url( $base ),
+				'href' => rest_url( sprintf( '/%s/%d/members', $base, $group_member->group_id ) ),
+			),
+			'group'      => array(
+				'href'       => rest_url( sprintf( '/%s/%d', $base, $group_member->group_id ) ),
+				'embeddable' => true,
 			),
 		);
 
@@ -760,10 +764,10 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		 *
 		 * @since 0.1.0
 		 *
-		 * @param array   $links The prepared links of the REST response.
-		 * @param WP_User $user  User object.
+		 * @param array $          links         The prepared links of the REST response.
+		 * @param BP_Groups_Member $group_member Group member object.
 		 */
-		return apply_filters( 'bp_rest_group_members_prepare_links', $links, $user );
+		return apply_filters( 'bp_rest_group_members_prepare_links', $links, $group_member );
 	}
 
 	/**
@@ -851,6 +855,12 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 
 			// Set title to this endpoint.
 			$schema['title'] = 'bp_group_members';
+
+			$schema['properties']['group_id'] = array(
+				'context'     => array( 'view', 'edit', 'embed' ),
+				'description' => __( 'A unique numeric ID for the Group.', 'buddypress' ),
+				'type'        => 'integer',
+			);
 
 			$schema['properties']['is_mod'] = array(
 				'context'     => array( 'view', 'edit' ),

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -957,11 +957,19 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'user'       => array(
+			'creator'    => array(
 				'href'       => rest_url( bp_rest_get_user_url( $group->creator_id ) ),
 				'embeddable' => true,
 			),
 		);
+
+		// Embed parent group if available.
+		if ( ! empty( $group->parent ) ) {
+			$links['parent'] = array(
+				'href'       => rest_url( $base . $group->parent ),
+				'embeddable' => true,
+			);
+		}
 
 		/**
 		 * Filter links prepared for the REST response.
@@ -1128,19 +1136,19 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				'type'       => 'object',
 				'properties' => array(
 					'id'                 => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'A unique numeric ID for the Group.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
 					'creator_id'         => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The ID of the user who created the Group.', 'buddypress' ),
 						'type'        => 'integer',
 						'default'     => bp_loggedin_user_id(),
 					),
 					'name'               => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The name of the Group.', 'buddypress' ),
 						'type'        => 'string',
 						'required'    => true,
@@ -1149,7 +1157,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 						),
 					),
 					'slug'               => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The URL-friendly slug for the Group.', 'buddypress' ),
 						'type'        => 'string',
 						'arg_options' => array(
@@ -1157,14 +1165,14 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 						),
 					),
 					'link'               => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The permalink to the Group on the site.', 'buddypress' ),
 						'type'        => 'string',
 						'format'      => 'uri',
 						'readonly'    => true,
 					),
 					'description'        => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The description of the Group.', 'buddypress' ),
 						'type'        => 'object',
 						'required'    => true,
@@ -1176,18 +1184,18 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 							'raw'      => array(
 								'description' => __( 'Content for the description of the Group, as it exists in the database.', 'buddypress' ),
 								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
+								'context'     => array( 'view', 'edit', 'embed' ),
 							),
 							'rendered' => array(
 								'description' => __( 'HTML content for the description of the Group, transformed for display.', 'buddypress' ),
 								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
+								'context'     => array( 'view', 'edit', 'embed' ),
 								'readonly'    => true,
 							),
 						),
 					),
 					'status'             => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The status of the Group.', 'buddypress' ),
 						'type'        => 'string',
 						'enum'        => buddypress()->groups->valid_status,
@@ -1197,24 +1205,24 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 						),
 					),
 					'enable_forum'       => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'Whether the Group has a forum enabled or not.', 'buddypress' ),
 						'type'        => 'boolean',
 					),
 					'parent_id'          => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'ID of the parent Group.', 'buddypress' ),
 						'type'        => 'integer',
 					),
 					'date_created'       => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( "The date the Group was created, in the site's timezone.", 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 						'format'      => 'date-time',
 					),
 					'types'              => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The type(s) of the Group.', 'buddypress' ),
 						'readonly'    => true,
 						'enum'        => bp_groups_get_group_types(),
@@ -1242,20 +1250,20 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 						),
 					),
 					'total_member_count' => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'Count of all Group members.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
 					'last_activity'      => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( "The date the Group was last active, in the site's timezone.", 'buddypress' ),
 						'type'        => 'string',
 						'readonly'    => true,
 						'format'      => 'date-time',
 					),
 					'last_activity_diff'  => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( "The human diff time the Group was last active, in the site's timezone.", 'buddypress' ),
 						'type'        => 'string',
 						'readonly'    => true,
@@ -1271,7 +1279,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 					'description' => sprintf( __( 'Avatar URL with full image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_full_width() ), number_format_i18n( bp_core_avatar_full_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				);
 
 				$avatar_properties['thumb'] = array(
@@ -1279,13 +1287,13 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 					'description' => sprintf( __( 'Avatar URL with thumb image size (%1$d x %2$d pixels).', 'buddypress' ), number_format_i18n( bp_core_avatar_thumb_width() ), number_format_i18n( bp_core_avatar_thumb_height() ) ),
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				);
 
 				$schema['properties']['avatar_urls'] = array(
 					'description' => __( 'Avatar URLs for the group.', 'buddypress' ),
 					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 					'properties'  => $avatar_properties,
 				);

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -957,7 +957,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'creator'    => array(
+			'user'    => array(
 				'href'       => rest_url( bp_rest_get_user_url( $group->creator_id ) ),
 				'embeddable' => true,
 			),

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -806,7 +806,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'id'                 => array(
 						'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
 						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
 					'name'               => array(
@@ -820,7 +820,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'mention_name'       => array(
 						'description' => __( 'The name used for that user in @-mentions.', 'buddypress' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'arg_options' => array(
 							'sanitize_callback' => 'sanitize_text_field',
 						),
@@ -830,13 +830,13 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						'description' => __( 'Profile URL of the member.', 'buddypress' ),
 						'type'        => 'string',
 						'format'      => 'uri',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
 					'user_login'         => array(
 						'description' => __( 'An alphanumeric identifier for the Member.', 'buddypress' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'required'    => true,
 						'arg_options' => array(
 							'sanitize_callback' => array( $this, 'check_username' ),
@@ -849,7 +849,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						'items'       => array(
 							'type' => 'string',
 						),
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
 					'registered_date'    => array(
@@ -897,14 +897,14 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'friendship_status'    => array(
 						'description' => __( 'Friendship relation with, current, logged in user.', 'buddypress' ),
 						'type'        => 'bool',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
 					'friendship_status_slug' => array(
 						'description' => __( 'Slug of the friendship status with current logged in user.', 'buddypress' ),
 						'enum'        => array( 'is_friend', 'not_friends', 'pending', 'awaiting_response' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
 					'last_activity'          => array(
@@ -948,7 +948,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						'readonly'    => true,
 					),
 					'total_friend_count'     => array(
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'Total number of friends for the member.', 'buddypress' ),
 						'type'        => 'integer',
 						'readonly'    => true,

--- a/tests/blogs/test-controller.php
+++ b/tests/blogs/test-controller.php
@@ -335,6 +335,6 @@ class BP_Test_REST_Blogs_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 }

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -1061,7 +1061,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 
 		// Single.
 		$request  = new WP_REST_Request( 'OPTIONS', sprintf( $this->endpoint_url . '/%d', $this->group_id ) );
@@ -1069,7 +1069,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function update_additional_field( $value, $data, $attribute ) {

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -774,7 +774,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 
 		// Single.
 		$request  = new WP_REST_Request( 'OPTIONS', sprintf( $this->endpoint_url . '/%d', self::$user ) );
@@ -782,7 +782,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function update_additional_field( $value, $data, $attribute ) {

--- a/tests/membership/test-group-membership-controller.php
+++ b/tests/membership/test-group-membership-controller.php
@@ -980,11 +980,12 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 23, count( $properties ) );
+		$this->assertEquals( 24, count( $properties ) );
 		$this->assertArrayHasKey( 'avatar_urls', $properties );
 		$this->assertArrayHasKey( 'capabilities', $properties );
 		$this->assertArrayHasKey( 'extra_capabilities', $properties );
 		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'group_id', $properties );
 		$this->assertArrayHasKey( 'link', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'mention_name', $properties );
@@ -1013,6 +1014,6 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit',  ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 }


### PR DESCRIPTION
fixes #393 

- Components were reviewed so that their `prepare_links` were correct
- Missing objects were added
- Some had their keys changed to better reflect what they are
- Embedable componets had their schema context updated (@imath it's important to review which fields **should not** be available when embedding an object)