### PR TITLE
Bump plugin version to 0.5.0

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -5,7 +5,7 @@
  * Description: BuddyPress extension for WordPress' JSON-based REST API.
  * Author: The BuddyPress Community
  * Author URI: https://buddypress.org/
- * Version: 0.4.0
+ * Version: 0.5.0
  * Text Domain: buddypress
  * Requires at least: 4.9
  * Tested up to: 5.6

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:       https://buddypress.org
 Requires at least: 4.9
 Tested up to:      5.6
 Requires PHP:      5.6
-Stable tag:        0.4.0
+Stable tag:        0.5.0
 License:           GPLv2
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
BuddyPress 8.0.0 was just released. FYI I’ve just created a 0.4 branch for it.
New `@since` in docblocks for 0.5.0 will be `9.0.0` 😉