### PR TITLE
Blogs: Remove user ID from avatar lookup

### DIFF
--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -428,7 +428,6 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 					array(
 						'type'          => 'thumb',
 						'blog_id'       => $blog->blog_id,
-						'admin_user_id' => $blog->admin_user_id,
 						'html'          => false,
 					)
 				),
@@ -436,7 +435,6 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 					array(
 						'type'          => 'full',
 						'blog_id'       => $blog->blog_id,
-						'admin_user_id' => $blog->admin_user_id,
 						'html'          => false,
 					)
 				),


### PR DESCRIPTION
Had a chance to use the `blogs` endpoint and noticed that the site avatar was always using the admin user's avatar instead of the site icon.

This PR fixes this by removing the `'user_id'` parameter from `bp_get_blog_avatar()`, which allows the proper site avatar to be used.