### PR TITLE
Stop using the deprecated `bp_rest_get_user_url()` function

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1108,7 +1108,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 
 		if ( ! empty( $activity->user_id ) ) {
 			$links['user'] = array(
-				'href'       => rest_url( bp_rest_get_user_url( absint( $activity->user_id ) ) ),
+				'href'       => rest_url( bp_rest_get_object_url( absint( $activity->user_id ), 'members' ) ),
 				'embeddable' => true,
 			);
 		}

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1108,7 +1108,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 
 		if ( ! empty( $activity->user_id ) ) {
 			$links['user'] = array(
-				'href'       => rest_url( bp_rest_get_object_url( absint( $activity->user_id ), 'members' ) ),
+				'href'       => bp_rest_get_object_url( absint( $activity->user_id ), 'members' ),
 				'embeddable' => true,
 			);
 		}

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -483,7 +483,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 
 		if ( ! empty( $blog->admin_user_id ) ) {
 			$links['user'] = array(
-				'href'       => rest_url( bp_rest_get_object_url( absint( $blog->admin_user_id ), 'members' ) ),
+				'href'       => bp_rest_get_object_url( absint( $blog->admin_user_id ), 'members' ),
 				'embeddable' => true,
 			);
 		}

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -483,7 +483,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 
 		if ( ! empty( $blog->admin_user_id ) ) {
 			$links['user'] = array(
-				'href'       => rest_url( bp_rest_get_user_url( absint( $blog->admin_user_id ) ) ),
+				'href'       => rest_url( bp_rest_get_object_url( absint( $blog->admin_user_id ), 'members' ) ),
 				'embeddable' => true,
 			);
 		}

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -684,11 +684,11 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'initiator'       => array(
-				'href'       => rest_url( bp_rest_get_user_url( $friendship->initiator_user_id ) ),
+				'href'       => rest_url( bp_rest_get_object_url( $friendship->initiator_user_id, 'members' ) ),
 				'embeddable' => true,
 			),
 			'friend'       => array(
-				'href'       => rest_url( bp_rest_get_user_url( $friendship->friend_user_id ) ),
+				'href'       => rest_url( bp_rest_get_object_url( $friendship->friend_user_id, 'members' ) ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -684,11 +684,11 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'initiator'       => array(
-				'href'       => rest_url( bp_rest_get_object_url( $friendship->initiator_user_id, 'members' ) ),
+				'href'       => bp_rest_get_object_url( $friendship->initiator_user_id, 'members' ),
 				'embeddable' => true,
 			),
 			'friend'       => array(
-				'href'       => rest_url( bp_rest_get_object_url( $friendship->friend_user_id, 'members' ) ),
+				'href'       => bp_rest_get_object_url( $friendship->friend_user_id, 'members' ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -838,7 +838,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'user'       => array(
-				'href'       => rest_url( bp_rest_get_user_url( $invite->user_id ) ),
+				'href'       => rest_url( bp_rest_get_object_url( $invite->user_id, 'members' ) ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -838,7 +838,7 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'user'       => array(
-				'href'       => rest_url( bp_rest_get_object_url( $invite->user_id, 'members' ) ),
+				'href'       => bp_rest_get_object_url( $invite->user_id, 'members' ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -748,7 +748,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		// Entity meta.
 		$links = array(
 			'self'       => array(
-				'href' => rest_url( bp_rest_get_user_url( $group_member->user_id ) ),
+				'href' => rest_url( bp_rest_get_object_url( $group_member->user_id, 'members' ) ),
 			),
 			'collection' => array(
 				'href' => rest_url( sprintf( '/%s/%d/members', $base, $group_member->group_id ) ),

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -748,7 +748,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		// Entity meta.
 		$links = array(
 			'self'       => array(
-				'href' => rest_url( bp_rest_get_object_url( $group_member->user_id, 'members' ) ),
+				'href' => bp_rest_get_object_url( $group_member->user_id, 'members' ),
 			),
 			'collection' => array(
 				'href' => rest_url( sprintf( '/%s/%d/members', $base, $group_member->group_id ) ),

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -775,7 +775,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'user'       => array(
-				'href'       => rest_url( bp_rest_get_user_url( $invite->user_id ) ),
+				'href'       => rest_url( bp_rest_get_object_url( $invite->user_id, 'members' ) ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-request-endpoint.php
@@ -775,7 +775,7 @@ class BP_REST_Group_Membership_Request_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'user'       => array(
-				'href'       => rest_url( bp_rest_get_object_url( $invite->user_id, 'members' ) ),
+				'href'       => bp_rest_get_object_url( $invite->user_id, 'members' ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -958,7 +958,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'user'    => array(
-				'href'       => rest_url( bp_rest_get_user_url( $group->creator_id ) ),
+				'href'       => rest_url( bp_rest_get_object_url( $group->creator_id, 'members' ) ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -958,7 +958,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base ),
 			),
 			'user'    => array(
-				'href'       => rest_url( bp_rest_get_object_url( $group->creator_id, 'members' ) ),
+				'href'       => bp_rest_get_object_url( $group->creator_id, 'members' ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -655,7 +655,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 		if ( ! empty( $notification->user_id ) ) {
 			$links['user'] = array(
 				'embeddable' => true,
-				'href'       => rest_url( bp_rest_get_object_url( absint( $notification->user_id ), 'members' ) ),
+				'href'       => bp_rest_get_object_url( absint( $notification->user_id ), 'members' ),
 			);
 		}
 

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -655,7 +655,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 		if ( ! empty( $notification->user_id ) ) {
 			$links['user'] = array(
 				'embeddable' => true,
-				'href'       => rest_url( bp_rest_get_user_url( absint( $notification->user_id ) ) ),
+				'href'       => rest_url( bp_rest_get_object_url( absint( $notification->user_id ), 'members' ) ),
 			);
 		}
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -465,7 +465,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base . $field_data->field_id ),
 			),
 			'user' => array(
-				'href'       => rest_url( bp_rest_get_object_url( $field_data->user_id, 'members' ) ),
+				'href'       => bp_rest_get_object_url( $field_data->user_id, 'members' ),
 				'embeddable' => true,
 			),
 		);

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -465,7 +465,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 				'href' => rest_url( $base . $field_data->field_id ),
 			),
 			'user' => array(
-				'href'       => rest_url( bp_rest_get_user_url( $field_data->user_id ) ),
+				'href'       => rest_url( bp_rest_get_object_url( $field_data->user_id, 'members' ) ),
 				'embeddable' => true,
 			),
 		);


### PR DESCRIPTION
Now [r12985](https://buddypress.trac.wordpress.org/changeset/12985) has been committed to BuddyPress trunk, we need to now use `bp_rest_get_object_url()` instead.