### PR TITLE
Add sitewide notices endpoint.

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -146,6 +146,10 @@ function bp_rest() {
 		require_once dirname( __FILE__ ) . '/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php';
 		$controller = new BP_REST_Messages_Endpoint();
 		$controller->register_routes();
+
+		require_once dirname( __FILE__ ) . '/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php';
+		$controller = new BP_REST_Sitewide_Notices_Endpoint();
+		$controller->register_routes();
 	}
 
 	if ( bp_is_active( 'notifications' ) ) {

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -610,7 +610,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		$previous = $this->prepare_item_for_response( $notice, $request );
 
 		// Delete a sitewide notice.
-		if ( ! bp_current_user_can( 'bp_moderate' ) || ! $notice->delete() ) {
+		if ( ! $notice->delete() ) {
 			return new WP_Error(
 				'bp_rest_sitewide_notice_delete_failed',
 				__( 'There was an error trying to delete a notice.', 'buddypress' ),

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -784,78 +784,80 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'bp_sitewide_notices',
-			'type'       => 'object',
-			'properties' => array(
-				'id'        => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'A unique numeric ID for the sitewide notice.', 'buddypress' ),
-					'type'        => 'integer',
-				),
-				'subject'   => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Subject of the sitewide notice.', 'buddypress' ),
-					'type'        => 'object',
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
+		if ( is_null( $this->schema ) ) {
+			$this->schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'bp_sitewide_notices',
+				'type'       => 'object',
+				'properties' => array(
+					'id'        => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'A unique numeric ID for the sitewide notice.', 'buddypress' ),
+						'type'        => 'integer',
 					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Title of the sitewide notice, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-							'default'     => false,
+					'subject'   => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Subject of the sitewide notice.', 'buddypress' ),
+						'type'        => 'object',
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
 						),
-						'rendered' => array(
-							'description' => __( 'Title of the sitewide notice, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'default'     => false,
-						),
-					),
-				),
-				'message'   => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Content of the sitewide notice.', 'buddypress' ),
-					'type'        => 'object',
-					'required'    => true,
-					'arg_options' => array(
-						'sanitize_callback' => null,
-						'validate_callback' => null,
-					),
-					'properties'  => array(
-						'raw'      => array(
-							'description' => __( 'Content for the sitewide notice, as it exists in the database.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'edit' ),
-						),
-						'rendered' => array(
-							'description' => __( 'HTML content for the sitewide notice, transformed for display.', 'buddypress' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Title of the sitewide notice, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+								'default'     => false,
+							),
+							'rendered' => array(
+								'description' => __( 'Title of the sitewide notice, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'default'     => false,
+							),
 						),
 					),
+					'message'   => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Content of the sitewide notice.', 'buddypress' ),
+						'type'        => 'object',
+						'required'    => true,
+						'arg_options' => array(
+							'sanitize_callback' => null,
+							'validate_callback' => null,
+						),
+						'properties'  => array(
+							'raw'      => array(
+								'description' => __( 'Content for the sitewide notice, as it exists in the database.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+							),
+							'rendered' => array(
+								'description' => __( 'HTML content for the sitewide notice, transformed for display.', 'buddypress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+					'date'      => array(
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( "The date of the sitewide notice, in the site's timezone.", 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'format'      => 'date-time',
+					),
+					'is_active' => array(
+						'context'     => array( 'edit' ),
+						'description' => __( 'Whether this notice is active or not.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'boolean',
+					),
 				),
-				'date'      => array(
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( "The date of the sitewide notice, in the site's timezone.", 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'string',
-					'format'      => 'date-time',
-				),
-				'is_active' => array(
-					'context'     => array( 'edit' ),
-					'description' => __( 'Whether this notice is active or not.', 'buddypress' ),
-					'readonly'    => true,
-					'type'        => 'boolean',
-				),
-			),
-		);
+			);
+		}
 
 		/**
 		 * Filters the notice schema.
@@ -864,7 +866,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
-		return apply_filters( 'bp_rest_sitewide_notices_schema', $this->add_additional_fields_schema( $schema ) );
+		return apply_filters( 'bp_rest_sitewide_notices_schema', $this->add_additional_fields_schema( $this->schema ) );
 	}
 
 	/**

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -565,7 +565,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		$request->set_param( 'context', 'edit' );
 
 		// Get the notice before it's deleted.
-		$notice   = $this->get_notice_object( $request->get_param( 'id' ) );
+		$notice = $this->get_notice_object( $request->get_param( 'id' ) );
 		if ( ! $notice->id ) {
 			return new WP_Error(
 				'bp_rest_invalid_id',

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -1,0 +1,917 @@
+<?php
+/**
+ * BP REST: BP_REST_Messages_Endpoint class
+ *
+ * @package BuddyPress
+ * @since 0.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Messages endpoints.
+ *
+ * @since 0.1.0
+ */
+class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.1.0
+	 */
+	public function __construct() {
+		$this->namespace = bp_rest_namespace() . '/' . bp_rest_version();
+		$this->rest_base = 'sitewide-notices';
+	}
+
+	/**
+	 * Register the component routes.
+	 *
+	 * @since 0.1.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		// (?P<id>[\d]+) is the placeholder for the notice ID.
+		$notice_endpoint = '/' . $this->rest_base . '/(?P<id>[\d]+)';
+
+		register_rest_route(
+			$this->namespace,
+			$notice_endpoint,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::READABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::DELETABLE ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		$dismiss_endpoint = '/' . $this->rest_base . '/dismiss/';
+
+		register_rest_route(
+			$this->namespace,
+			$dismiss_endpoint,
+			array(
+				'args'   => array(
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'dismiss_notice' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ), // Anyone who can get items can dismiss them.
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Select the item schema arguments needed for the CREATABLE, EDITABLE and DELETABLE methods.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $method Optional. HTTP method of the request.
+	 * @return array Endpoint arguments.
+	 */
+	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
+		$key                       = 'get_item';
+		$args                      = WP_REST_Controller::get_endpoint_args_for_item_schema( $method );
+		$args['id']['description'] = __( 'ID of the sitewide notice.', 'buddypress' );
+
+		if ( WP_REST_Server::CREATABLE === $method ) {
+			$key = 'create_item';
+
+			// Edit the Thread ID description and default properties.
+			$args['id']['description'] = __( 'ID of the sitewide notice. Required when editing an existing notice.', 'buddypress' );
+			$args['id']['default']     = 0;
+
+
+			// Edit subject's properties.
+			$args['subject']['type']        = 'string';
+			$args['subject']['default']     = false;
+			$args['subject']['description'] = __( 'Subject of the sitewide notice.', 'buddypress' );
+
+			// Edit message's properties.
+			$args['message']['type']        = 'string';
+			$args['message']['description'] = __( 'Content of the sitewide notice.', 'buddypress' );
+
+		} else {
+			unset( $args['subject'], $args['message'] );
+
+			if ( WP_REST_Server::EDITABLE === $method ) {
+				$key = 'update_item';
+
+				$args['id'] = array(
+					'description'       => __( 'ID of the sitewide notice to update. Required when editing an existing notice.', 'buddypress' ),
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+					'validate_callback' => 'rest_validate_request_arg',
+				);
+			}
+
+			if ( WP_REST_Server::DELETABLE === $method ) {
+				$key = 'delete_item';
+
+				$args['id'] = array(
+					'description'       => __( 'The ID of the sitewide notice to delete', 'buddypress' ),
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+					'validate_callback' => 'rest_validate_request_arg',
+					'default'           => 0,
+				);
+			}
+		}
+
+		/**
+		 * Filters the method query arguments.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array $args Query arguments.
+		 * @param string $method HTTP method of the request.
+		 */
+		return apply_filters( "bp_rest_sitewide_notices_{$key}_query_arguments", $args, $method );
+	}
+
+	/**
+	 * Retrieve sitewide notices.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+
+		if ( 'edit' === $context && bp_current_user_can( 'bp_moderate' ) ) {
+
+			$args = array(
+				'pag_num'  => isset( $request['per_page'] ) ? absint( $request['per_page'] ) : 20,
+				'pag_page' => isset( $request['page'] ) ? absint( $request['page'] ) : 1,
+			);
+
+			/**
+			 * Filter the query arguments for the request.
+			 *
+			 * @since 0.1.0
+			 *
+			 * @param array           $args    Key value array of query var to query value.
+			 * @param WP_REST_Request $request The request sent to the API.
+			 */
+			$args = apply_filters( 'bp_rest_sitewide_notices_get_items_query_args', $args, $request );
+
+			$notices = BP_Messages_Notice::get_notices( $args );
+
+			$retval = array();
+			foreach ( (array) $notices as $notice ) {
+				$retval[] = $this->prepare_response_for_collection(
+					$this->prepare_item_for_response( $notice, $request )
+				);
+			}
+
+			$response = rest_ensure_response( $retval );
+			$response = bp_rest_response_add_total_headers( $response, BP_Messages_Notice::get_total_notice_count(), $args['pag_num'] );
+
+		} else {
+			// Ordinary users, or Admins who aren't currently managing notices, only get the most recent notice.
+			$retval = array();
+			$notice = BP_Messages_Notice::get_active();
+			if ( ! empty( $notice ) ) {
+				// Make sure the user hasn't already dismissed it.
+				$closed_notices = bp_get_user_meta( bp_loggedin_user_id(), 'closed_notices', true );
+				if ( empty( $closed_notices ) ) {
+					$closed_notices = array();
+				}
+				if ( $notice->id && is_array( $closed_notices ) && ! in_array( $notice->id, $closed_notices, true ) ) {
+					$retval[] = $this->prepare_response_for_collection(
+						$this->prepare_item_for_response( $notice, $request )
+					);
+				}
+			}
+			$response = rest_ensure_response( $retval );
+			// The count is either 0 or 1, since there can only be one active notice at a time.
+			$response = bp_rest_response_add_total_headers( $response, count( $retval ), 1 );
+		}
+
+		/**
+		 * Fires after notices are fetched via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice $notices  Fetched notices.
+		 * @param WP_REST_Response   $response The response data.
+		 * @param WP_REST_Request    $request  The request sent to the API.
+		 */
+		do_action( 'bp_rest_sitewide_notices_get_items', $notices, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request is allowed to get notices.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|bool
+	 */
+	public function get_items_permissions_check( $request ) {
+		$retval  = true;
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+
+		if ( ! is_user_logged_in() || ( 'edit' === $context && ! bp_current_user_can( 'bp_moderate' ) ) ) {
+			$retval = new WP_Error(
+				'bp_rest_authorization_required',
+				__( 'Sorry, you are not allowed to see the notices.', 'buddypress' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		/**
+		 * Filter the messages `get_items` permissions check.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_get_items_permissions_check', $retval, $request );
+	}
+
+	/**
+	 * Get a single notice by ID.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$notice = $this->get_notice_object( $request['id'] );
+
+		$retval = array(
+			$this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $notice, $request )
+			),
+		);
+
+		$response = rest_ensure_response( $retval );
+
+		/**
+		 * Fires after a sitewide notice is fetched via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice $notice  Notice object.
+		 * @param WP_REST_Response   $retval  The response data.
+		 * @param WP_REST_Request    $request The request sent to the API.
+		 */
+		do_action( 'bp_rest_sitewide_notices_get_item', $notice, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request is allowed to get a sitewide notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|bool
+	 */
+	public function get_item_permissions_check( $request ) {
+		$retval = true;
+
+		if ( ! is_user_logged_in() ) {
+			$retval = new WP_Error(
+				'bp_rest_authorization_required',
+				__( 'Sorry, you are not allowed to read notices.', 'buddypress' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		$notice = $this->get_notice_object( $request['id'] );
+
+		if ( true === $retval && empty( $notice->id ) ) {
+			$retval = new WP_Error(
+				'bp_rest_invalid_id',
+				__( 'Sorry, this notice does not exist.', 'buddypress' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		if ( true === $retval && bp_current_user_can( 'bp_moderate' ) ) {
+			$retval = true;
+		} else {
+			// Non-admin users can only see the active notice.
+			$is_active = isset( $notice->is_active ) ? $notice->is_active : false;
+			if ( true === $retval && ! $is_active ) {
+				$retval = new WP_Error(
+					'bp_rest_authorization_required',
+					__( 'Sorry, you are not allowed to see this notice.', 'buddypress' ),
+					array(
+						'status' => rest_authorization_required_code(),
+					)
+				);
+			}
+		}
+
+		/**
+		 * Filter the sitewide notices `get_item` permissions check.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_get_item_permissions_check', $retval, $request, $notice );
+	}
+
+	/**
+	 * Create a sitewide notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$subject = isset( $request['subject'] ) ? $request['subject'] : '';
+		$message = isset( $request['message'] ) ? $request['message'] : '';
+		$success = messages_send_notice( $subject, $message );
+
+		if ( ! $success ) {
+			return new WP_Error(
+				'bp_rest_user_cannot_create_sitewide_notice',
+				__( 'Cannot create new sitewide notice.', 'buddypress' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		// The notice we just created will be active.
+		$notice        = BP_Messages_Notice::get_active();
+		$fields_update = $this->update_additional_fields_for_object( $notice, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
+		$retval = array(
+			$this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $notice, $request )
+			),
+		);
+
+		$response = rest_ensure_response( $retval );
+
+		/**
+		 * Fires after a sitewide notice is created via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice $notice   Notice object.
+		 * @param WP_REST_Response   $response The response data.
+		 * @param WP_REST_Request    $request  The request sent to the API.
+		 */
+		do_action( 'bp_rest_sitewide_notices_create_item', $notice, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to create a notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function create_item_permissions_check( $request ) {
+		$retval = $this->manage_item_permissions_check( $request );
+
+		/**
+		 * Filter the sitewide notices `create_item` permissions check.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_create_item_permissions_check', $retval, $request );
+	}
+
+	/**
+	 * Update a notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$test_notice = $this->get_notice_object( $request['id'] );
+		if ( ! $test_notice->id ) {
+			return new WP_Error(
+				'bp_rest_sitewide_notices_update_failed',
+				__( 'There was an error trying to update the notice.', 'buddypress' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		$notice = $this->prepare_item_for_database( $request );
+		$notice->save();
+
+		$fields_update = $this->update_additional_fields_for_object( $notice, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
+		$retval = array(
+			$this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $notice, $request )
+			),
+		);
+
+		$response = rest_ensure_response( $retval );
+
+		/**
+		 * Fires after a sitewide notice is updated via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice  $notice    Notice object.
+		 * @param WP_REST_Response    $response  The response data.
+		 * @param WP_REST_Request     $request   The request sent to the API.
+		 */
+		do_action( 'bp_rest_sitewide_notices_update_item', $notice, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to update a notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function update_item_permissions_check( $request ) {
+		$retval = $this->manage_item_permissions_check( $request );
+
+		/**
+		 * Filter the sitewide notices `update_item` permissions check.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_update_item_permissions_check', $retval, $request );
+	}
+
+	/**
+	 * Dismisses the currently active notice for the current user.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function dismiss_notice( $request ) {
+		// Mark the active notice as closed.
+		$notice    = BP_Messages_Notice::get_active();
+		$previous  = $this->prepare_item_for_response( $notice, $request );
+		$dismissed = false;
+
+		if ( is_user_logged_in() && ! empty( $notice->id ) ) {
+			$user_id        = bp_loggedin_user_id();
+			$closed_notices = bp_get_user_meta( $user_id, 'closed_notices', true );
+
+			if ( empty( $closed_notices ) ) {
+				$closed_notices = array();
+			}
+
+			// Add the notice to the array of the user's closed notices.
+			$closed_notices[] = (int) $notice->id;
+			bp_update_user_meta( $user_id, 'closed_notices', array_map( 'absint', array_unique( $closed_notices ) ) );
+
+			$dismissed = true;
+		}
+
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'dismissed' => $dismissed,
+				'previous'  => $previous->get_data(),
+			)
+		);
+
+		/**
+		 * Fires after a sitewide notice is dismissed via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice  $notice   Notice object.
+		 * @param WP_REST_Response    $response The response data.
+		 * @param WP_REST_Request     $request  The request sent to the API.
+		 */
+		do_action( 'bp_rest_sitewide_notices_dismiss_notice', $notice, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Delete a sitewide notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		// Get the notice before it's deleted.
+		$notice   = $this->get_notice_object( $request['id'] );
+		$previous = $this->prepare_item_for_response( $notice, $request );
+
+		// Delete a thread.
+		if ( ! bp_current_user_can( 'bp_moderate' ) || ! $notice->delete() ) {
+			return new WP_Error(
+				'bp_rest_sitewide_notice_delete_failed',
+				__( 'There was an error trying to delete a notice.', 'buddypress' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		// Build the response.
+		$response = new WP_REST_Response();
+		$response->set_data(
+			array(
+				'deleted'  => true,
+				'previous' => $previous->get_data(),
+			)
+		);
+
+		/**
+		 * Fires after a sitewide notice is deleted via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice $notice  Notice object.
+		 * @param WP_REST_Response   $response The response data.
+		 * @param WP_REST_Request    $request  The request sent to the API.
+		 */
+		do_action( 'bp_rest_sitewide_notices_delete_item', $thread, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to generally manage a notice.
+	 * Granular filters are provided in the edit_, create_, and delete_
+	 * permissions checks.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function manage_item_permissions_check( $request ) {
+		$retval = bp_current_user_can( 'bp_moderate' );
+
+		/**
+		 * Filter the notice `manage_item` permissions check.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_manage_item_permissions_check', $retval, $request );
+	}
+
+	/**
+	 * Check if a given request has access to delete a notice.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$retval = $this->manage_item_permissions_check( $request );
+
+		/**
+		 * Filter the sitewide notices `create_item` permissions check.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_delete_item_permissions_check', $retval, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param BP_Messages_Notice $notice  Notice object.
+	 * @return array Links for the given notice.
+	 */
+	protected function prepare_links( $notice ) {
+		$base = sprintf( '/%s/%s/', $this->namespace, $this->rest_base );
+
+		// Entity meta.
+		$links = array(
+			'self'       => array(
+				'href' => rest_url( $base . $notice->id ),
+			),
+			'collection' => array(
+				'href' => rest_url( $base ),
+			),
+		);
+
+		/**
+		 * Filter links prepared for the REST response.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array              $links   The prepared links of the REST response.
+		 * @param BP_Messages_Notice $notice  Notice object.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_prepare_links', $links, $notice );
+	}
+
+	/**
+	 * Prepares sitewide notice data for return as an object.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param BP_Messages_Notice $notice  Notice object.
+	 * @param WP_REST_Request    $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $notice, $request ) {
+
+		$data = array(
+			'id'        => $notice->id,
+			'subject'   => array(
+				'raw'      => $notice->subject,
+				'rendered' => apply_filters( 'bp_get_sitewide_notice_subject', wp_staticize_emoji( $notice->subject ) ),
+			),
+			'message'   => array(
+				'raw'      => $notice->message,
+				'rendered' => apply_filters( 'bp_get_sitewide_notice_content', wp_staticize_emoji( $notice->message ) ),
+			),
+			'date'      => bp_rest_prepare_date_response( $notice->date_sent ),
+			'is_active' => $notice->is_active,
+		);
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $notice ) );
+
+		/**
+		 * Filter sitewide notice data returned from the API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param WP_REST_Response   $response Response generated by the request.
+		 * @param WP_REST_Request    $request  Request used to generate the response.
+		 * @param BP_Messages_Notice $notice   Notice object.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_prepare_value', $response, $request, $notice );
+	}
+
+	/**
+	 * Get sitewide notice object.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param int $id Notice ID.
+	 * @return BP_Messages_Notice
+	 */
+	public function get_notice_object( $id ) {
+		return new BP_Messages_Notice( $id );
+	}
+
+	/**
+	 * Get the message schema, conforming to JSON Schema.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'bp_sitewide_notices',
+			'type'       => 'object',
+			'properties' => array(
+				'id'        => array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'A unique numeric ID for the sitewide notice.', 'buddypress' ),
+					'type'        => 'integer',
+				),
+				'subject'   => array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'Subject of the sitewide notice.', 'buddypress' ),
+					'type'        => 'object',
+					'arg_options' => array(
+						'sanitize_callback' => null,
+						'validate_callback' => null,
+					),
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'Title of the sitewide notice, as it exists in the database.', 'buddypress' ),
+							'type'        => 'string',
+							'context'     => array( 'edit' ),
+							'default'     => false,
+						),
+						'rendered' => array(
+							'description' => __( 'Title of the sitewide notice, transformed for display.', 'buddypress' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'default'     => false,
+						),
+					),
+				),
+				'message'   => array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'Content of the sitewide notice.', 'buddypress' ),
+					'type'        => 'object',
+					'required'    => true,
+					'arg_options' => array(
+						'sanitize_callback' => null,
+						'validate_callback' => null,
+					),
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'Content for the sitewide notice, as it exists in the database.', 'buddypress' ),
+							'type'        => 'string',
+							'context'     => array( 'edit' ),
+						),
+						'rendered' => array(
+							'description' => __( 'HTML content for the sitewide notice, transformed for display.', 'buddypress' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+				'date'      => array(
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( "The date of the sitewide notice, in the site's timezone.", 'buddypress' ),
+					'readonly'    => true,
+					'type'        => 'string',
+					'format'      => 'date-time',
+				),
+				'is_active' => array(
+					'context'     => array( 'edit' ),
+					'description' => __( 'Whether this notice is active or not.', 'buddypress' ),
+					'readonly'    => true,
+					'type'        => 'boolean',
+				),
+			),
+		);
+
+		/**
+		 * Filters the notice schema.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array $schema The endpoint schema.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_schema', $this->add_additional_fields_schema( $schema ) );
+	}
+
+	/**
+	 * Get the query params for sitewide notices collections.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                       = parent::get_collection_params();
+		$params['context']['default'] = 'view';
+
+		/**
+		 * Filters the collection query params.
+		 *
+		 * @param array $params Query params.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_collection_params', $params );
+	}
+
+	/**
+	 * Prepare a notice for creation or update.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return BP_Messages_Notice|WP_Error Object or WP_Error.
+	 */
+	protected function prepare_item_for_database( $request ) {
+
+		$schema          = $this->get_item_schema();
+		$notice_id       = isset( $request['id'] ) ? absint( $request['id'] ) : 0;
+		$prepared_item   = $this->get_notice_object( $notice_id );
+
+		// Notice ID.
+		if ( ! empty( $schema['properties']['id'] ) && ! empty( $prepared_item->id ) ) {
+			$prepared_item->id = $prepared_item->id;
+		}
+
+		// Notice subject.
+		if ( ! empty( $schema['properties']['subject'] ) && isset( $request['subject'] ) ) {
+			if ( is_string( $request['subject'] ) ) {
+				$prepared_item->subject = $request['subject'];
+			} elseif ( isset( $request['subject']['raw'] ) ) {
+				$prepared_item->subject = $request['subject']['raw'];
+			}
+		}
+
+		// Notice message.
+		if ( ! empty( $schema['properties']['message'] ) && isset( $request['message'] ) ) {
+			if ( is_string( $request['message'] ) ) {
+				$prepared_item->message = $request['message'];
+			} elseif ( isset( $request['subject']['raw'] ) ) {
+				$prepared_item->message = $request['message']['raw'];
+			}
+		}
+
+		// Date_sent is set at creation, so nothing to do.
+
+		// Is active
+		if ( ! empty( $schema['properties']['is_active'] ) && isset( $request['is_active'] ) ) {
+			$prepared_item->is_active = $request['is_active'];
+		}
+
+		/**
+		 * Filters a notice before it is updated via the REST API.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param BP_Messages_Notice $prepared_item A BP_Messages_Notice object prepared for inserting or updating the database.
+		 * @param WP_REST_Request $request Request object.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_pre_update_value', $prepared_item, $request );
+	}
+}

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -3,7 +3,7 @@
  * BP REST: BP_REST_Messages_Endpoint class
  *
  * @package BuddyPress
- * @since 0.1.0
+ * @since 9.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -11,14 +11,14 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Messages endpoints.
  *
- * @since 0.1.0
+ * @since 9.0.0
  */
 class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 
 	/**
 	 * Constructor.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 */
 	public function __construct() {
 		$this->namespace = bp_rest_namespace() . '/' . bp_rest_version();
@@ -28,7 +28,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Register the component routes.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -101,7 +101,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Select the item schema arguments needed for the CREATABLE, EDITABLE and DELETABLE methods.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param string $method Optional. HTTP method of the request.
 	 * @return array Endpoint arguments.
@@ -160,7 +160,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filters the method query arguments.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param array $args Query arguments.
 		 * @param string $method HTTP method of the request.
@@ -171,7 +171,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Retrieve sitewide notices.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response
@@ -190,7 +190,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			/**
 			 * Filter the query arguments for the request.
 			 *
-			 * @since 0.1.0
+			 * @since 9.0.0
 			 *
 			 * @param array           $args    Key value array of query var to query value.
 			 * @param WP_REST_Request $request The request sent to the API.
@@ -233,7 +233,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Fires after notices are fetched via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice $notices  Fetched notices.
 		 * @param WP_REST_Response   $response The response data.
@@ -247,7 +247,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Check if a given request is allowed to get notices.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|bool
@@ -269,7 +269,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter the messages `get_items` permissions check.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param bool|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
@@ -280,7 +280,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Get a single notice by ID.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_REST_Response
@@ -299,7 +299,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Fires after a sitewide notice is fetched via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice $notice  Notice object.
 		 * @param WP_REST_Response   $retval  The response data.
@@ -313,7 +313,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Check if a given request is allowed to get a sitewide notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|bool
@@ -362,7 +362,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter the sitewide notices `get_item` permissions check.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param bool|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
@@ -373,7 +373,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Create a sitewide notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
@@ -412,7 +412,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Fires after a sitewide notice is created via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice $notice   Notice object.
 		 * @param WP_REST_Response   $response The response data.
@@ -426,7 +426,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Check if a given request has access to create a notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool
@@ -437,7 +437,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter the sitewide notices `create_item` permissions check.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param bool|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
@@ -448,7 +448,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Update a notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
@@ -484,7 +484,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Fires after a sitewide notice is updated via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice  $notice    Notice object.
 		 * @param WP_REST_Response    $response  The response data.
@@ -498,7 +498,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Check if a given request has access to update a notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool
@@ -509,7 +509,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter the sitewide notices `update_item` permissions check.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param bool|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
@@ -520,7 +520,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Dismisses the currently active notice for the current user.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
@@ -558,7 +558,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Fires after a sitewide notice is dismissed via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice  $notice   Notice object.
 		 * @param WP_REST_Response    $response The response data.
@@ -572,7 +572,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Delete a sitewide notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
@@ -605,7 +605,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Fires after a sitewide notice is deleted via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice $notice  Notice object.
 		 * @param WP_REST_Response   $response The response data.
@@ -621,7 +621,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * Granular filters are provided in the edit_, create_, and delete_
 	 * permissions checks.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool
@@ -632,7 +632,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter the notice `manage_item` permissions check.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param bool|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
@@ -643,7 +643,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Check if a given request has access to delete a notice.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool
@@ -654,7 +654,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter the sitewide notices `create_item` permissions check.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param bool|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
@@ -665,7 +665,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param BP_Messages_Notice $notice  Notice object.
 	 * @return array Links for the given notice.
@@ -686,7 +686,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter links prepared for the REST response.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param array              $links   The prepared links of the REST response.
 		 * @param BP_Messages_Notice $notice  Notice object.
@@ -697,7 +697,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Prepares sitewide notice data for return as an object.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param BP_Messages_Notice $notice  Notice object.
 	 * @param WP_REST_Request    $request Full details about the request.
@@ -729,7 +729,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filter sitewide notice data returned from the API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param WP_REST_Response   $response Response generated by the request.
 		 * @param WP_REST_Request    $request  Request used to generate the response.
@@ -741,7 +741,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Get sitewide notice object.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param int $id Notice ID.
 	 * @return BP_Messages_Notice
@@ -753,7 +753,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Get the message schema, conforming to JSON Schema.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @return array
 	 */
@@ -834,7 +834,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filters the notice schema.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param array $schema The endpoint schema.
 		 */
@@ -844,7 +844,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Get the query params for sitewide notices collections.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @return array
 	 */
@@ -863,7 +863,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	/**
 	 * Prepare a notice for creation or update.
 	 *
-	 * @since 0.1.0
+	 * @since 9.0.0
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return BP_Messages_Notice|WP_Error Object or WP_Error.
@@ -907,7 +907,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		/**
 		 * Filters a notice before it is updated via the REST API.
 		 *
-		 * @since 0.1.0
+		 * @since 9.0.0
 		 *
 		 * @param BP_Messages_Notice $prepared_item A BP_Messages_Notice object prepared for inserting or updating the database.
 		 * @param WP_REST_Request $request Request object.

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -86,7 +86,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			)
 		);
 
-		$dismiss_endpoint = '/' . $this->rest_base . '/dismiss/';
+		$dismiss_endpoint = '/' . $this->rest_base . '/dismiss';
 
 		register_rest_route(
 			$this->namespace,
@@ -682,21 +682,21 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			'id'        => $notice->id,
 			'subject'   => array(
 				'raw'      => $notice->subject,
-				'rendered' => apply_filters( 'bp_get_sitewide_notice_subject', wp_staticize_emoji( $notice->subject ) ),
+				'rendered' => apply_filters( 'bp_get_message_notice_subject', wp_staticize_emoji( $notice->subject ) ),
 			),
 			'message'   => array(
 				'raw'      => $notice->message,
-				'rendered' => apply_filters( 'bp_get_sitewide_notice_content', wp_staticize_emoji( $notice->message ) ),
+				'rendered' => apply_filters( 'bp_get_message_notice_text', wp_staticize_emoji( $notice->message ) ),
 			),
 			'date'      => bp_rest_prepare_date_response( $notice->date_sent ),
 			'is_active' => $notice->is_active,
 		);
 
 		$context = $request->get_param( 'context' );
-		// @TODO: There must be something wrong here.
-		if ( empty( $context ) ) {
+		if ( ! $context ) {
 			$context = 'view';
 		}
+
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -211,8 +211,9 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 
 		} else {
 			// Ordinary users, or Admins who aren't currently managing notices, only get the most recent notice.
-			$retval = array();
-			$notice = BP_Messages_Notice::get_active();
+			$retval  = array();
+			$notice  = BP_Messages_Notice::get_active();
+			$notices = array();
 			if ( ! empty( $notice ) ) {
 				// Make sure the user hasn't already dismissed it.
 				$closed_notices = bp_get_user_meta( bp_loggedin_user_id(), 'closed_notices', true );
@@ -223,6 +224,8 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 					$retval[] = $this->prepare_response_for_collection(
 						$this->prepare_item_for_response( $notice, $request )
 					);
+					// Add the item to the notices array used in the filter.
+					$notices[] = $notice;
 				}
 			}
 			$response = rest_ensure_response( $retval );

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -509,7 +509,17 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return WP_Error|bool
 	 */
 	public function dismiss_notice_permissions_check( $request ) {
-		$retval = $this->get_items_permissions_check( $request );
+		$retval  = new WP_Error(
+			'bp_rest_authorization_required',
+			__( 'Sorry, you are not allowed to dismiss notices.', 'buddypress' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+
+		if ( is_user_logged_in() ) {
+			$retval = true;
+		}
 
 		/**
 		 * Filter the sitewide notices `dismiss_notice` permissions check.

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -91,7 +91,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'dismiss_notice' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ), // Anyone who can get items can dismiss them.
+					'permission_callback' => array( $this, 'dismiss_notice_permissions_check' ), // Anyone who can get items can dismiss them.
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
@@ -567,6 +567,28 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		do_action( 'bp_rest_sitewide_notices_dismiss_notice', $notice, $response, $request );
 
 		return $response;
+	}
+
+	/**
+	 * Check if a given request has access to dismiss the current notice.
+	 *
+	 * @since 9.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function dismiss_notice_permissions_check( $request ) {
+		$retval = $this->get_items_permissions_check( $request );
+
+		/**
+		 * Filter the sitewide notices `dismiss_notice` permissions check.
+		 *
+		 * @since 9.0.0
+		 *
+		 * @param bool|WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'bp_rest_sitewide_notices_dismiss_notice_permissions_check', $retval, $request );
 	}
 
 	/**

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -509,7 +509,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return WP_Error|bool
 	 */
 	public function dismiss_notice_permissions_check( $request ) {
-		$retval  = new WP_Error(
+		$retval = new WP_Error(
 			'bp_rest_authorization_required',
 			__( 'Sorry, you are not allowed to dismiss notices.', 'buddypress' ),
 			array(

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * BP REST: BP_REST_Messages_Endpoint class
+ * BP REST: BP_REST_Sitewide_Notices_Endpoint class
  *
  * @package BuddyPress
  * @since 9.0.0
@@ -9,7 +9,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Messages endpoints.
+ * Sitewide Notices endpoints.
  *
  * @since 9.0.0
  */
@@ -611,7 +611,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		$notice   = $this->get_notice_object( $request->get_param( 'id' ) );
 		$previous = $this->prepare_item_for_response( $notice, $request );
 
-		// Delete a thread.
+		// Delete a sitewide notice.
 		if ( ! bp_current_user_can( 'bp_moderate' ) || ! $notice->delete() ) {
 			return new WP_Error(
 				'bp_rest_sitewide_notice_delete_failed',

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -58,6 +58,12 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			$this->namespace,
 			$notice_endpoint,
 			array(
+				'args' => array(
+					'id' => array(
+						'description' => __( 'A unique numeric ID for the Sitewide notice.', 'buddypress' ),
+						'type'        => 'integer',
+					),
+				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
@@ -86,7 +92,6 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			$this->namespace,
 			$dismiss_endpoint,
 			array(
-				'args'   => array(),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'dismiss_notice' ),
@@ -895,6 +900,8 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 
 		/**
 		 * Filters the collection query params.
+		 *
+		 * @since 9.0.0
 		 *
 		 * @param array $params Query params.
 		 */

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -86,8 +86,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			$this->namespace,
 			$dismiss_endpoint,
 			array(
-				'args'   => array(
-				),
+				'args'   => array(),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'dismiss_notice' ),
@@ -117,7 +116,6 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			// Edit the Thread ID description and default properties.
 			$args['id']['description'] = __( 'ID of the sitewide notice. Required when editing an existing notice.', 'buddypress' );
 			$args['id']['default']     = 0;
-
 
 			// Edit subject's properties.
 			$args['subject']['type']        = 'string';
@@ -178,7 +176,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 
 		if ( 'edit' === $context && bp_current_user_can( 'bp_moderate' ) ) {
 
@@ -266,7 +264,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		);
 
 		if ( is_user_logged_in() ) {
-		    if ( 'view' === $context ) {
+			if ( 'view' === $context ) {
 				$retval = true;
 			} elseif ( 'edit' === $context ) {
 				$retval = bp_current_user_can( 'bp_moderate' );
@@ -761,7 +759,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 		$context = $request->get_param( 'context' );
 		// @TODO: There must be something wrong here.
 		if ( empty( $context ) ) {
-			$context = "view";
+			$context = 'view';
 		}
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
@@ -913,9 +911,9 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 */
 	protected function prepare_item_for_database( $request ) {
 
-		$schema          = $this->get_item_schema();
-		$notice_id       = $request->get_param( 'id' );
-		$prepared_item   = $this->get_notice_object( $notice_id );
+		$schema        = $this->get_item_schema();
+		$notice_id     = $request->get_param( 'id' );
+		$prepared_item = $this->get_notice_object( $notice_id );
 
 		// Notice ID.
 		if ( ! empty( $schema['properties']['id'] ) && ! empty( $prepared_item->id ) ) {
@@ -944,7 +942,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 
 		// Date_sent is set at creation, so nothing to do.
 
-		// Is active
+		// Is active.
 		$is_active = $request->get_param( 'is_active' );
 		if ( ! empty( $schema['properties']['is_active'] ) && ! is_null( $is_active ) ) {
 			// The method get_param() returns a string, so we must convert to an integer.

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -51,12 +51,9 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			)
 		);
 
-		// (?P<id>[\d]+) is the placeholder for the notice ID.
-		$notice_endpoint = '/' . $this->rest_base . '/(?P<id>[\d]+)';
-
 		register_rest_route(
 			$this->namespace,
-			$notice_endpoint,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
 			array(
 				'args' => array(
 					'id' => array(
@@ -86,11 +83,9 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			)
 		);
 
-		$dismiss_endpoint = '/' . $this->rest_base . '/dismiss';
-
 		register_rest_route(
 			$this->namespace,
-			$dismiss_endpoint,
+			'/' . $this->rest_base . '/dismiss',
 			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -111,8 +106,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$context = $request->get_param( 'context' );
 
 		if ( 'edit' === $context && bp_current_user_can( 'bp_moderate' ) ) {
 
@@ -255,14 +249,14 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return WP_Error|bool
 	 */
 	public function get_item_permissions_check( $request ) {
-
-		$retval = new WP_Error(
+		$error  = new WP_Error(
 			'bp_rest_authorization_required',
-			__( 'Sorry, you are not allowed to read notices.', 'buddypress' ),
+			__( 'Sorry, you are not allowed to see this notice.', 'buddypress' ),
 			array(
 				'status' => rest_authorization_required_code(),
 			)
 		);
+		$retval = $error;
 
 		if ( is_user_logged_in() ) {
 			$notice = $this->get_notice_object( $request->get_param( 'id' ) );
@@ -281,13 +275,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 					// Non-admin users can only see the active notice.
 					$is_active = isset( $notice->is_active ) ? $notice->is_active : false;
 					if ( ! $is_active ) {
-						$retval = new WP_Error(
-							'bp_rest_authorization_required',
-							__( 'Sorry, you are not allowed to see this notice.', 'buddypress' ),
-							array(
-								'status' => rest_authorization_required_code(),
-							)
-						);
+						$retval = $error;
 					} else {
 						$retval = true;
 					}
@@ -710,7 +698,6 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $notice, $request ) {
-
 		$data = array(
 			'id'        => $notice->id,
 			'subject'   => array(
@@ -948,7 +935,6 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 	 * @return BP_Messages_Notice|WP_Error Object or WP_Error.
 	 */
 	protected function prepare_item_for_database( $request ) {
-
 		$schema        = $this->get_item_schema();
 		$notice_id     = $request->get_param( 'id' );
 		$prepared_item = $this->get_notice_object( $notice_id );

--- a/tests/sitewide-notices/test-controller.php
+++ b/tests/sitewide-notices/test-controller.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * Sitewide Notices Endpoint Tests.
+ *
+ * @package BuddyPress
+ * @subpackage BP_REST
+ * @group notices
+ */
+class BP_Test_REST_Sitewide_Notices_Endpoint extends WP_Test_REST_Controller_Testcase {
+	protected $last_inserted_notice_id;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->bp_factory   = new BP_UnitTest_Factory();
+		$this->endpoint     = new BP_REST_Sitewide_Notices_Endpoint();
+		$this->bp           = new BP_UnitTestCase();
+		$this->endpoint_url = '/' . bp_rest_namespace() . '/' . bp_rest_version() . '/sitewide-notices';
+		$this->user         = $this->factory->user->create( array(
+			'role'       => 'administrator',
+			'user_email' => 'admin@example.com',
+		) );
+
+		if ( ! $this->server ) {
+			$this->server = rest_get_server();
+		}
+
+		$this->old_current_user = get_current_user_id();
+
+		add_action( 'messages_notice_before_save', array( $this, 'add_filter_update_last_active_query' ), 10, 0 );
+		add_action( 'messages_notice_after_save', array( $this, 'set_last_inserted_notice_id' ), 10, 1 );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->bp->set_current_user( $this->old_current_user );
+
+		remove_action( 'messages_notice_before_save', array( $this, 'filter_update_last_active_query' ), 10, 0 );
+		remove_action( 'messages_notice_after_save', array( $this, 'set_last_inserted_notice_id' ), 10, 1 );
+	}
+
+	public function catch_inserted_id( $query ) {
+		preg_match( '/SET is_active = 0 WHERE id != (.*)/', $query, $matches );
+		if ( isset( $matches[1] ) && $matches[1] ) {
+			$this->last_inserted_notice_id = (int) $matches[1];
+		}
+
+		return $query;
+	}
+
+	public function add_filter_update_last_active_query() {
+		add_filter( 'query', array( $this, 'catch_inserted_id' ) );
+	}
+
+	public function set_last_inserted_notice_id( $notice_obj ) {
+		remove_filter( 'query', array( $this, 'catch_inserted_id' ) );
+
+		if ( $this->last_inserted_notice_id ) {
+			$notice_obj->id = $this->last_inserted_notice_id;
+			$this->last_inserted_notice_id = null;
+		}
+	}
+
+	public function test_register_routes() {
+		$routes   = $this->server->get_routes();
+		$endpoint = $this->endpoint_url;
+
+		// Main.
+		$this->assertArrayHasKey( $endpoint, $routes );
+		$this->assertCount( 2, $routes[ $endpoint ] );
+
+		// Single.
+		$single_endpoint = $endpoint . '/(?P<id>[\d]+)';
+
+		$this->assertArrayHasKey( $single_endpoint, $routes );
+		$this->assertCount( 3, $routes[ $single_endpoint ] );
+
+		// Dismiss.
+		$dismiss_endpoint = $endpoint . '/dismiss';
+
+		$this->assertArrayHasKey( $dismiss_endpoint, $routes );
+		$this->assertCount( 1, $routes[ $dismiss_endpoint ] );
+	}
+
+	public function create_notice( $notices = array() ) {
+		$created = array();
+
+		foreach ( $notices as $notice ) {
+			$props = wp_parse_args(
+				$notice,
+				array(
+					'subject'   => 'example subject',
+					'message'   => 'example message',
+					'date_sent' => bp_core_current_time(),
+					'is_active' => 1,
+				)
+			);
+
+			$new_notice = new BP_Messages_Notice();
+
+			foreach ( $props as $key => $prop ) {
+				$new_notice->{$key} = $prop;
+			}
+
+			if ( $new_notice->save() ) {
+				$created[] = $new_notice;
+			}
+		}
+
+		return $created;
+	}
+
+	/**
+	 * @group get_items
+	 */
+	public function test_get_items() {
+		$this->bp->set_current_user( $this->user );
+		$tested = array(
+			'n1' => array(
+				'subject' => 'foo',
+			),
+			'n2' => array(
+				'subject' => 'bar',
+			),
+		);
+
+		$created = $this->create_notice( $tested );
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$all_data = $response->get_data();
+		$this->assertNotEmpty( $all_data );
+		$this->assertTrue( 2 === count( $all_data ) );
+
+		$data   = wp_list_filter( $all_data, array( 'is_active' => true ) );
+		$data_n = reset( $data );
+
+		$n = wp_filter_object_list( $created, array( 'id' => $data_n['id'] ), 'and', 'id' );
+		$key = key( $n );
+
+		$this->check_notice_data( $created[ $key ], $data_n, 'edit' );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item() {
+		$this->bp->set_current_user( $this->user );
+		$tested = array(
+			'n1' => array(
+				'subject'   => 'foo',
+				'is_active' => 0,
+			),
+			'n2' => array(
+				'subject' => 'bar',
+			),
+		);
+
+		$created = $this->create_notice( $tested );
+
+		$n   = wp_filter_object_list( $created, array( 'is_active' => 1 ), 'and', 'id' );
+		$id  = current( $n );
+		$key = key( $n );
+
+		$u1 = $this->factory->user->create();
+		$this->bp->set_current_user( $u1 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . '/' . $id );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->check_notice_data( $created[ $key ], $data, 'view' );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_admin_access() {
+		$this->bp->set_current_user( $this->user );
+		$tested = array(
+			'n1' => array(
+				'subject'   => 'foo',
+				'is_active' => 0,
+			),
+			'n2' => array(
+				'subject' => 'bar',
+			),
+		);
+
+		$created = $this->create_notice( $tested );
+
+		$n   = wp_filter_object_list( $created, array( 'is_active' => 0 ), 'and', 'id' );
+		$id  = current( $n );
+		$key = key( $n );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . '/' . $id );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->check_notice_data( $created[ $key ], $data, 'edit' );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_no_access() {
+		$this->bp->set_current_user( $this->user );
+		$tested = array(
+			'n1' => array(
+				'subject'   => 'foo',
+				'is_active' => 0,
+			),
+			'n2' => array(
+				'subject' => 'bar',
+			),
+		);
+
+		$created = $this->create_notice( $tested );
+
+		$n   = wp_filter_object_list( $created, array( 'is_active' => 0 ), 'and', 'id' );
+		$id  = current( $n );
+		$key = key( $n );
+
+		$u1 = $this->factory->user->create();
+		$this->bp->set_current_user( $u1 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . '/' . $id );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group create_item
+	 */
+	public function test_create_item() {
+		$this->markTestSkipped();
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_item() {
+		$this->markTestSkipped();
+	}
+
+	/**
+	 * @group delete_item
+	 */
+	public function test_delete_item() {
+		$this->markTestSkipped();
+	}
+
+	/**
+	 * @group dismiss_item
+	 */
+	public function test_dismiss_item() {
+		$this->markTestSkipped();
+	}
+
+	/**
+	 * @group prepare_links
+	 */
+	public function test_prepare_add_links_to_response() {
+		$this->markTestSkipped();
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_prepare_item() {
+		$this->markTestSkipped();
+	}
+
+	protected function check_notice_data( $notice, $data, $context = 'view' ) {
+		$this->assertEquals( $notice->id, $data['id'] );
+
+		if ( 'edit' === $context ) {
+			$this->assertEquals( $notice->subject, $data['subject']['raw'] );
+			$this->assertEquals( $notice->message, $data['message']['raw'] );
+			$this->assertEquals( (bool) $notice->is_active, $data['is_active'] );
+		}
+
+		$this->assertEquals( apply_filters( 'bp_get_message_notice_subject', wp_staticize_emoji( $notice->subject ) ), $data['subject']['rendered'] );
+		$this->assertEquals( apply_filters( 'bp_get_message_notice_text', wp_staticize_emoji( $notice->message ) ), $data['message']['rendered'] );
+		$this->assertEquals( bp_rest_prepare_date_response( $notice->date_sent ), $data['date'] );
+	}
+
+	public function test_get_item_schema() {
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint_url );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 5, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'subject', $properties );
+		$this->assertArrayHasKey( 'message', $properties );
+		$this->assertArrayHasKey( 'date', $properties );
+		$this->assertArrayHasKey( 'is_active', $properties );
+	}
+
+	public function test_context_param() {
+		// Collection.
+		$request  = new WP_REST_Request( 'OPTIONS', $this->endpoint_url );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+}

--- a/tests/sitewide-notices/test-controller.php
+++ b/tests/sitewide-notices/test-controller.php
@@ -368,29 +368,10 @@ class BP_Test_REST_Sitewide_Notices_Endpoint extends WP_Test_REST_Controller_Tes
 	/**
 	 * @group get_item
 	 */
-	public function test_get_item_not_exist() {
+	public function test_get_item_with_invalid_id() {
 		$this->bp->set_current_user( $this->user );
-		$tested = array(
-			'n1' => array(
-				'subject'   => 'bar',
-				'is_active' => 0,
-			),
-			'n2' => array(
-				'subject' => 'foo',
-			),
-		);
 
-		$created = $this->create_notice( $tested );
-
-		$n   = wp_filter_object_list( $created, array( 'is_active' => 1 ), 'and', 'id' );
-		$id  = current( $n );
-		$key = key( $n );
-
-		// Make it disappear!
-		$to_delete = new BP_Messages_Notice( $id );
-		$to_delete->delete();
-
-		$request = new WP_REST_Request( 'GET', $this->endpoint_url . '/' . $id );
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . '/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 
@@ -537,22 +518,10 @@ class BP_Test_REST_Sitewide_Notices_Endpoint extends WP_Test_REST_Controller_Tes
 	/**
 	 * @group update_item
 	 */
-	public function test_update_item_not_exist() {
+	public function test_update_item_with_invalid_id() {
 		$this->bp->set_current_user( $this->user );
-		$tested = array(
-			'n1' => array(
-				'subject' => 'Foo Bar',
-			),
-		);
 
-		$created = $this->create_notice( $tested );
-		$n = current( $created );
-
-		// Make it disappear!
-		$to_delete = new BP_Messages_Notice( $n->id );
-		$to_delete->delete();
-
-		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', $n->id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$request->set_param( 'message', 'Ouch!' );
 		$response = $this->server->dispatch( $request );
 
@@ -611,22 +580,10 @@ class BP_Test_REST_Sitewide_Notices_Endpoint extends WP_Test_REST_Controller_Tes
 	/**
 	 * @group delete_item
 	 */
-	public function test_delete_item_not_exist() {
+	public function test_delete_item_with_invalid_id() {
 		$this->bp->set_current_user( $this->user );
-		$tested = array(
-			'n1' => array(
-				'subject' => 'Ouch!',
-			),
-		);
 
-		$created = $this->create_notice( $tested );
-		$n = current( $created );
-
-		// Make it disappear!
-		$to_delete = new BP_Messages_Notice( $n->id );
-		$to_delete->delete();
-
-		$request = new WP_REST_Request( 'DELETE', sprintf( $this->endpoint_url . '/%d', $n->id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( $this->endpoint_url . '/%d', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'bp_rest_invalid_id', $response, 404 );


### PR DESCRIPTION
Allow any logged-in user to fetch currently active notices that they haven't dismissed.
Allow any logged-in user to dismiss the currently active notice.
Allow site admins to create, fetch, and update sitewide notices.