### PR TITLE
Add a new `registered_since` property to the Members schema

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -500,6 +500,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		);
 
 		if ( $request->get_param( 'populate_extras' ) ) {
+			$data['registered_since']          = bp_core_time_since( $user->user_registered );
 			$data['last_activity']['timediff'] = '';
 			$data['last_activity']['date']     = '';
 
@@ -857,6 +858,12 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						'type'        => 'string',
 						'format'      => 'date-time',
 						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+					'registered_since'   => array(
+						'description' => __( 'Elapsed time since the member registered.', 'buddypress' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
 						'readonly'    => true,
 					),
 					'password'           => array(

--- a/tests/members/test-controller.php
+++ b/tests/members/test-controller.php
@@ -721,7 +721,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 18, count( $properties ) );
+		$this->assertEquals( 19, count( $properties ) );
 		$this->assertArrayHasKey( 'avatar_urls', $properties );
 		$this->assertArrayHasKey( 'capabilities', $properties );
 		$this->assertArrayHasKey( 'extra_capabilities', $properties );
@@ -730,6 +730,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'mention_name', $properties );
 		$this->assertArrayHasKey( 'registered_date', $properties );
+		$this->assertArrayHasKey( 'registered_since', $properties );
 		$this->assertArrayHasKey( 'password', $properties );
 		$this->assertArrayHasKey( 'roles', $properties );
 		$this->assertArrayHasKey( 'member_types', $properties );

--- a/tests/membership/test-group-membership-controller.php
+++ b/tests/membership/test-group-membership-controller.php
@@ -980,7 +980,7 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 24, count( $properties ) );
+		$this->assertEquals( 25, count( $properties ) );
 		$this->assertArrayHasKey( 'avatar_urls', $properties );
 		$this->assertArrayHasKey( 'capabilities', $properties );
 		$this->assertArrayHasKey( 'extra_capabilities', $properties );
@@ -990,6 +990,7 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'mention_name', $properties );
 		$this->assertArrayHasKey( 'registered_date', $properties );
+		$this->assertArrayHasKey( 'registered_since', $properties );
 		$this->assertArrayHasKey( 'password', $properties );
 		$this->assertArrayHasKey( 'roles', $properties );
 		$this->assertArrayHasKey( 'xprofile', $properties );


### PR DESCRIPTION
This is needed by the Dynamic Members Widget block when filtering members according to their registration date (newest filter).

See https://github.com/buddypress/bp-blocks/blob/8ac19a789b1bc94c3aaca2a9834e68f96477066d/src/bp-members/js/dynamic-members.js#L75 for context.