### PR TITLE
Add a new property `created_since` to the Groups item schema

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -723,6 +723,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'creator_id'         => bp_get_group_creator_id( $item ),
 			'parent_id'          => $item->parent_id,
 			'date_created'       => bp_rest_prepare_date_response( $item->date_created ),
+			'created_since'      => bp_core_time_since( $item->date_created ),
 			'description'        => array(
 				'raw'      => $item->description,
 				'rendered' => bp_get_group_description( $item ),
@@ -1222,6 +1223,13 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 						'readonly'    => true,
 						'type'        => 'string',
 						'format'      => 'date-time',
+					),
+					'created_since'      => array(
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'description' => __( 'Time elapsed since the Group was created, in the site\'s timezone.', 'buddypress' ),
+						'readonly'    => true,
+						'type'        => 'string',
+						'default'     => '',
 					),
 					'types'              => array(
 						'context'     => array( 'view', 'edit', 'embed' ),

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -1016,7 +1016,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 17, count( $properties ) );
+		$this->assertEquals( 18, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'creator_id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
@@ -1026,6 +1026,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'enable_forum', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
+		$this->assertArrayHasKey( 'created_since', $properties );
 		$this->assertArrayHasKey( 'admins', $properties );
 		$this->assertArrayHasKey( 'mods', $properties );
 		$this->assertArrayHasKey( 'types', $properties );


### PR DESCRIPTION
This is needed by the Groups Dynamic Widget Block see [bp-blocks#52](https://github.com/buddypress/bp-blocks/pull/52/files#diff-28a91593413762c683a693126c2b9db73d07650c435d952f86136fea2f746e00R70)