### PR TITLE
Bump Plugin version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We have extensive documentation of each endpoint/components and their CRUD actio
 
 * PHP >= 5.6
 * WP >= 4.9
-* BuddyPress >= 6.0.0
+* BuddyPress >= 9.0.0
 
 ## Endpoints (Components) Supported
 

--- a/bp-rest.php
+++ b/bp-rest.php
@@ -5,7 +5,7 @@
  * Description: BuddyPress extension for WordPress' JSON-based REST API.
  * Author: The BuddyPress Community
  * Author URI: https://buddypress.org/
- * Version: 0.5.0
+ * Version: 0.6.0
  * Text Domain: buddypress
  * Requires at least: 4.9
  * Tested up to: 5.6

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:       https://buddypress.org
 Requires at least: 4.9
 Tested up to:      5.6
 Requires PHP:      5.6
-Stable tag:        0.5.0
+Stable tag:        0.6.0
 License:           GPLv2
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,7 +21,20 @@ Access your BuddyPress site's data through an easy-to-use HTTP REST API.
 
 == Changelog ==
 
+= 0.5.0 =
+* Inclusion in BuddyPress 9.0.0
+
+= 0.4.0 =
+* Inclusion in BuddyPress 8.0.0
+
+= 0.3.0 =
+* Inclusion in BuddyPress 7.0.0
+
+= 0.2.0 =
+* Inclusion in BuddyPress 6.0.0
+
 = 0.1.0 =
+* Inclusion in BuddyPress 5.0.0
 * First release
 
 == Upgrade Notice ==


### PR DESCRIPTION
Hi @renatonascalves 

I've just created https://github.com/buddypress/BP-REST/tree/0.5 for BuddyPress 9.0 branch

0.6.0 version will be included into BuddyPress 10.0.0