### PR TITLE
XProfile: Update Checkbox field type properly

### DIFF
--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -214,9 +214,9 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		 * For field types not supporting multiple values, join values in case
 		 * the submitted value was not an array.
 		 */
-		if ( ! $field->type_obj->supports_multiple_defaults ) {
+		if ( false === $field->type_obj->supports_multiple_defaults ) {
 			$value = implode( ' ', (array) $value );
-		} else {
+		} elseif ( is_string( $value ) ) {
 			$value = preg_split( '/[,]+/', $value );
 		}
 
@@ -255,9 +255,9 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		 *
 		 * @param BP_XProfile_Field       $field      The field object.
 		 * @param BP_XProfile_ProfileData $field_data The field data object.
-		 * @param WP_User                 $user      The user object.
-		 * @param WP_REST_Response        $response  The response data.
-		 * @param WP_REST_Request         $request   The request sent to the API.
+		 * @param WP_User                 $user       The user object.
+		 * @param WP_REST_Response        $response   The response data.
+		 * @param WP_REST_Request         $request    The request sent to the API.
 		 */
 		do_action( 'bp_rest_xprofile_data_save_item', $field, $field_data, $user, $response, $request );
 
@@ -375,10 +375,10 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 		 * @since 0.1.0
 		 *
 		 * @param BP_XProfile_Field       $field       Deleted field object.
-		 * @param BP_XProfile_ProfileData  $field_data  Deleted field data object.
-		 * @param WP_User                $user       User object.
-		 * @param WP_REST_Response       $response   The response data.
-		 * @param WP_REST_Request        $request    The request sent to the API.
+		 * @param BP_XProfile_ProfileData $field_data  Deleted field data object.
+		 * @param WP_User                 $user        User object.
+		 * @param WP_REST_Response        $response    The response data.
+		 * @param WP_REST_Request         $request     The request sent to the API.
 		 */
 		do_action( 'bp_rest_xprofile_data_delete_item', $field, $field_data, $user, $response, $request );
 

--- a/tests/xprofile/test-data-controller.php
+++ b/tests/xprofile/test-data-controller.php
@@ -88,10 +88,136 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 		$request->add_header( 'content-type', 'application/json' );
 
 		$params = $this->set_field_data();
+		$request->set_param( 'context', 'edit' );
 		$request->set_body( wp_json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->check_create_field_response( $response );
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_checkbox_item_param_as_string() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'checkbox',
+				'field_group_id' => $this->group_id
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data();
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( $data[0]['value']['unserialized'], array( 'Field', 'Value' ) );
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_checkbox_item_as_array() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'checkbox',
+				'name'           => 'Test Field Name',
+				'field_group_id' => $this->group_id
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => [ 'field', 'value' ] ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( $data[0]['value']['unserialized'], array( 'field', 'value' ) );
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_textbox_item() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'textbox',
+				'name'           => 'Test Field Name',
+				'field_group_id' => $this->group_id
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => 'textbox field' ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( $data[0]['value']['unserialized'][0], 'textbox field' );
+		$this->assertEquals( $data[0]['value']['raw'], 'textbox field' );
+	}
+
+	/**
+	 * @group update_item
+	 */
+	public function test_update_selectbox_item() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'selectbox',
+				'name'           => 'Test Field Name',
+				'field_group_id' => $this->group_id
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => [ 'select',  'box' ] ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( $data[0]['value']['unserialized'][0], 'select box' );
+		$this->assertEquals( $data[0]['value']['raw'], 'select box' );
 	}
 
 	/**


### PR DESCRIPTION
This was raised at https://buddypress.trac.wordpress.org/ticket/8537

Currently, if you pass an `array` with values and your XProfile field does not acccept multiple default values, we pass the value to `preg_split` which accepts a `string` not an `array`.

Note: if you pass a `string` value to a field that supports an `array`, we turn that `string` into an `array` of values. This is so that REST API users can add value such as `field value`, or `value1,value2,value3` and the endpoint will be smart enough to update it correctly in BuddyPress.

This was fixed in this pull request and unit test coverage was also improved.