### PR TITLE
Groups: when creating a group activity, save the item_id correctly

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1040,13 +1040,13 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( ! empty( $schema['properties']['primary_item_id'] ) && ! empty( $request->get_param( 'primary_item_id' ) ) ) {
 			$item_id = (int) $request->get_param( 'primary_item_id' );
 
+			// Use a generic item ID.
+			$prepared_activity->item_id = $item_id;
+
 			// Set the group ID, used in the `groups_post_update` helper function only.
 			if ( bp_is_active( 'groups' ) && isset( $prepared_activity->component ) && buddypress()->groups->id === $prepared_activity->component ) {
 				$prepared_activity->group_id = $item_id;
 			}
-
-			// Use a generic item ID.
-			$prepared_activity->item_id = $item_id;
 		}
 
 		// Secondary Item ID.

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1040,14 +1040,13 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		if ( ! empty( $schema['properties']['primary_item_id'] ) && ! empty( $request->get_param( 'primary_item_id' ) ) ) {
 			$item_id = (int) $request->get_param( 'primary_item_id' );
 
-			// Set the group ID of the activity.
+			// Set the group ID, used in the `groups_post_update` helper function only.
 			if ( bp_is_active( 'groups' ) && isset( $prepared_activity->component ) && buddypress()->groups->id === $prepared_activity->component ) {
 				$prepared_activity->group_id = $item_id;
-
-				// Use a generic item ID for other components.
-			} else {
-				$prepared_activity->item_id = $item_id;
 			}
+
+			// Use a generic item ID.
+			$prepared_activity->item_id = $item_id;
 		}
 
 		// Secondary Item ID.

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -961,11 +961,15 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'user'    => array(
+		);
+
+		// Embed group creator if available.
+		if ( ! empty( $group->creator_id ) ) {
+			$links['user'] = array(
 				'href'       => bp_rest_get_object_url( $group->creator_id, 'members' ),
 				'embeddable' => true,
-			),
-		);
+			);
+		}
 
 		// Embed parent group if available.
 		if ( ! empty( $group->parent ) ) {

--- a/tests/activity/test-controller.php
+++ b/tests/activity/test-controller.php
@@ -1144,7 +1144,8 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$params = $this->set_activity_data(
 			array(
-				'content' => 'Updated random content',
+				'content'         => 'Updated random content',
+				'primary_item_id' => $g,
 			)
 		);
 		$request->set_body( wp_json_encode( $params ) );
@@ -1154,8 +1155,13 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->check_update_activity_response( $response );
 
 		$new_data = $response->get_data();
-		$new_data = $new_data[0];
+		$this->assertNotEmpty( $new_data );
 
+		$new_data = $new_data[0];
+		$activity = $this->endpoint->get_activity_object( $a );
+
+		$this->assertEquals( $g, $activity->item_id );
+		$this->assertEquals( $g, $new_data['primary_item_id'] );
 		$this->assertEquals( $a, $new_data['id'] );
 		$this->assertEquals( $params['content'], $new_data['content']['raw'] );
 	}
@@ -1547,6 +1553,7 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayNotHasKey( 'Location', $headers );
 
 		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
 
 		$activity = $this->endpoint->get_activity_object( $data[0]['id'] );
 		$this->check_activity_data( $activity, $data[0], 'edit' );


### PR DESCRIPTION
Issue raised at https://buddypress.trac.wordpress.org/ticket/8524

When creating a group activity, `groups_post_update` needs a `group_id` but the rest of the `create_item` and `update_item` actions need a `item_id`, which was missing.