### PR TITLE
Fix failing `BP_Test_REST_Group_Endpoint::test_get_items_extra()` test

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,9 +13,9 @@ jobs:
         wp_version: ['master']
         include:
           - php: '8.0'
-            wp_version: '5.7'
+            wp_version: '5.8'
           - php: '7.4'
-            wp_version: '5.7'
+            wp_version: '5.8'
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_VERSION: ${{ matrix.wp_version }}

--- a/tests/groups/test-controller.php
+++ b/tests/groups/test-controller.php
@@ -157,7 +157,8 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	 * @group get_items
 	 */
 	public function test_get_items_extra() {
-		$this->bp->set_current_user( $this->user );
+		$u1 = $this->bp_factory->user->create();
+		$this->bp->set_current_user( $u1 );
 		$now = time();
 
 		$d1 = gmdate( 'Y-m-d H:i:s', $now - 10000 );
@@ -169,8 +170,8 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$a2 = $this->bp_factory->group->create( array( 'date_created' => $d2 ) );
 		$a3 = $this->bp_factory->group->create( array( 'date_created' => $d3 ) );
 
-		$u = $this->factory->user->create();
-		groups_join_group( $a3, $u );
+		$u2 = $this->bp_factory->user->create();
+		groups_join_group( $a3, $u2);
 
 		groups_update_groupmeta( $a1, 'last_activity', $d4 );
 


### PR DESCRIPTION
Use the BP unit test factory to create the user. This is needed due to the change introduce in BuddyPress 10.0.0 about how the total group member count is calculated. See `BP_Groups_Group::get_total_member_count()` in  [13103](https://buddypress.trac.wordpress.org/changeset/13103/).

See #426