### PR TITLE
Updates: packages, PHPCs, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,15 @@ Access your BuddyPress site's data through an easy-to-use HTTP REST API.
 
 We have extensive documentation of each endpoint/components and their CRUD actions: <https://developer.buddypress.org/bp-rest-api/>
 
-## System Requirements
+## System Requirements (relevant for CI tests only)
 
-* PHP >= 5.6
-* WP >= 4.9
-* BuddyPress >= 9.0.0
-
-## Endpoints (Components) Supported
-
-* [x] Activity `http://site.com/wp-json/buddypress/v1/activity`
-* [x] Groups `http://site.com/wp-json/buddypress/v1/groups`
-* [x] Group Membership `http://site.com/wp-json/buddypress/v1/groups/<group_id>/members`
-* [x] Group Membership Request(s) `http://site.com/wp-json/buddypress/v1/groups/{group_id}/membership-request/`
-* [x] Group Avatar `http://site.com/wp-json/buddypress/v1/groups/<group_id>/avatar`
-* [x] Group Cover `http://site.com/wp-json/buddypress/v1/groups/<group_id>/cover`
-* [x] Group Invites `http://site.com/wp-json/buddypress/v1/groups/<group_id>/invites`
-* [x] XProfile Fields `http://site.com/wp-json/buddypress/v1/xprofile/fields`
-* [x] XProfile Groups `http://site.com/wp-json/buddypress/v1/xprofile/groups`
-* [x] XProfile Data `http://site.com/wp-json/buddypress/v1/xprofile/<field_id>/data/<user_id>`
-* [x] Members `http://site.com/wp-json/buddypress/v1/members`
-* [x] Members Profile Photo (aka Avatar) `http://site.com/wp-json/buddypress/v1/members/<user_id>/avatar`
-* [x] Members Cover `http://site.com/wp-json/buddypress/v1/members/<user_id>/cover`
-* [x] Notifications `http://site.com/wp-json/buddypress/v1/notifications`
-* [x] Components `http://site.com/wp-json/buddypress/v1/components`
-* [x] Messages `http://site.com/wp-json/buddypress/v1/messages`
-* [x] Signup `http://site.com/wp-json/buddypress/v1/signup`
-* [x] Friends `http://site.com/wp-json/buddypress/v1/friends`
-* [x] Blogs `http://site.com/wp-json/buddypress/v1/blogs`
-* [x] Blog Avatar `http://site.com/wp-json/buddypress/v1/blogs/<id>/avatar`
+* PHP >= 7.5
+* WP >= 5.8
+* BuddyPress >= Latest
 
 ## Installation
 
-Drop this plugin in the wp-content/plugins directory and activate it. You need at least [WordPress 4.9](https://wordpress.org/download/) and [BuddyPress](https://buddypress.org/download/) to use the plugin.
+Drop this plugin in the wp-content/plugins directory and activate it. You need at least [WordPress 5.4](https://wordpress.org/download/) and [BuddyPress](https://buddypress.org/download/) to use the plugin.
 
 ## About
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
     "wp-coding-standards/wpcs": "*",
     "phpunit/phpunit": "^7.5",
-    "wp-phpunit/wp-phpunit": "^5.7"
+    "wp-phpunit/wp-phpunit": "^5.8",
+    "yoast/phpunit-polyfills": "^1.0"
   },
   "scripts": {
     "phpcs" : "phpcs . --basepath=.",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "phpcs" : "phpcs . --basepath=.",
-    "phpcbf": "phpcbf .",
+    "phpcbf": "phpcbf . --basepath=.",
     "phpunit": "phpunit",
     "phpunit:mu": "phpunit -c tests/multisite.xml"
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3419b1831d50fb3efb3dc49ac08cc1a4",
+    "content-hash": "5bd36be27ccd11b509b4ed3e4b74db5c",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "ae03311f45dfe194412081526be2e003960df74b"
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
-                "reference": "ae03311f45dfe194412081526be2e003960df74b",
+                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
                 "shasum": ""
             },
             "require": {
@@ -116,6 +116,7 @@
                 "modx",
                 "moodle",
                 "osclass",
+                "pantheon",
                 "phpbb",
                 "piwik",
                 "ppi",
@@ -138,7 +139,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.11.0"
+                "source": "https://github.com/composer/installers/tree/v1.12.0"
             },
             "funding": [
                 {
@@ -154,7 +155,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-28T06:42:17+00:00"
+            "time": "2021-09-13T08:19:44+00:00"
         }
     ],
     "packages-dev": [
@@ -585,16 +586,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
                 "shasum": ""
             },
             "require": {
@@ -635,7 +636,7 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-02-15T12:58:46+00:00"
+            "time": "2021-07-21T11:09:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -692,16 +693,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -712,7 +713,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -742,22 +744,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
                 "shasum": ""
             },
             "require": {
@@ -765,7 +767,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -791,39 +794,39 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-10-02T14:08:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -858,9 +861,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -931,16 +934,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/28af674ff175d0768a5a978e6de83f697d4a7f05",
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05",
                 "shasum": ""
             },
             "require": {
@@ -979,7 +982,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.4"
             },
             "funding": [
                 {
@@ -987,7 +990,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2021-07-19T06:46:01+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1095,16 +1098,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
@@ -1142,7 +1145,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
             },
             "funding": [
                 {
@@ -1151,7 +1154,7 @@
                 }
             ],
             "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1501,16 +1504,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
+                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
                 "shasum": ""
             },
             "require": {
@@ -1519,7 +1522,7 @@
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1566,7 +1569,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.4"
             },
             "funding": [
                 {
@@ -1574,7 +1577,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2021-11-11T13:51:24+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1907,16 +1910,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -1959,20 +1962,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -1984,7 +1987,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2022,7 +2025,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2038,20 +2041,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -2080,7 +2083,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -2088,7 +2091,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2201,16 +2204,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.7.1",
+            "version": "5.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375"
+                "reference": "0cefcc49fd8a7e8c2f8d755e314532441618aee5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/5ab77c1e1328e9bee65f60c246e33b13fc202375",
-                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/0cefcc49fd8a7e8c2f8d755e314532441618aee5",
+                "reference": "0cefcc49fd8a7e8c2f8d755e314532441618aee5",
                 "shasum": ""
             },
             "type": "library",
@@ -2245,7 +2248,68 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2021-03-10T17:57:07+00:00"
+            "time": "2021-11-10T19:49:29+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],
@@ -2257,5 +2321,5 @@
         "php": ">=5.6.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1375,7 +1375,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'date_gmt'              => array(
+					'date_gmt'          => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The date the activity was published, as GMT.', 'buddypress' ),
 						'readonly'    => true,

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -427,16 +427,16 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 			$data['avatar_urls'] = array(
 				'thumb' => bp_get_blog_avatar(
 					array(
-						'type'          => 'thumb',
-						'blog_id'       => $blog->blog_id,
-						'html'          => false,
+						'type'    => 'thumb',
+						'blog_id' => $blog->blog_id,
+						'html'    => false,
 					)
 				),
 				'full'  => bp_get_blog_avatar(
 					array(
-						'type'          => 'full',
-						'blog_id'       => $blog->blog_id,
-						'html'          => false,
+						'type'    => 'full',
+						'blog_id' => $blog->blog_id,
+						'html'    => false,
 					)
 				),
 			);
@@ -645,19 +645,19 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 				'title'      => 'bp_blogs',
 				'type'       => 'object',
 				'properties' => array(
-					'id'            => array(
+					'id'                => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'A unique numeric ID for the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
-					'user_id'       => array(
+					'user_id'           => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'A unique numeric ID for the blog admin.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
-					'name'          => array(
+					'name'              => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The name of the blog.', 'buddypress' ),
 						'readonly'    => true,
@@ -666,14 +666,14 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
-					'permalink'     => array(
+					'permalink'         => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The permalink of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 						'format'      => 'uri',
 					),
-					'description'        => array(
+					'description'       => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The description of the blog.', 'buddypress' ),
 						'type'        => 'object',
@@ -695,19 +695,19 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 							),
 						),
 					),
-					'path'          => array(
+					'path'              => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The path of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 					),
-					'domain'        => array(
+					'domain'            => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The domain of the blog.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'string',
 					),
-					'last_activity' => array(
+					'last_activity'     => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The date of the last activity from the blog, in the site\'s timezone.', 'buddypress' ),
 						'readonly'    => true,
@@ -721,7 +721,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'lastest_post_id' => array(
+					'lastest_post_id'   => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The latest post ID from the blog', 'buddypress' ),
 						'type'        => 'integer',

--- a/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
+++ b/includes/bp-friends/classes/class-bp-rest-friends-endpoint.php
@@ -684,11 +684,11 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'initiator'       => array(
+			'initiator'  => array(
 				'href'       => bp_rest_get_object_url( $friendship->initiator_user_id, 'members' ),
 				'embeddable' => true,
 			),
-			'friend'       => array(
+			'friend'     => array(
 				'href'       => bp_rest_get_object_url( $friendship->friend_user_id, 'members' ),
 				'embeddable' => true,
 			),
@@ -820,28 +820,28 @@ class BP_REST_Friends_Endpoint extends WP_REST_Controller {
 				'title'      => 'bp_friends',
 				'type'       => 'object',
 				'properties' => array(
-					'id'           => array(
+					'id'               => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Unique numeric identifier of the friendship.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-					'initiator_id' => array(
+					'initiator_id'     => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The unique numeric identifier of the user who is requesting the Friendship.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-					'friend_id'    => array(
+					'friend_id'        => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The unique numeric identifier of the user who is invited to agree to the Friendship request.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-					'is_confirmed' => array(
+					'is_confirmed'     => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Whether the friendship been confirmed/accepted.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'boolean',
 					),
-					'date_created' => array(
+					'date_created'     => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The date the friendship was created, in the site\'s timezone.', 'buddypress' ),
 						'readonly'    => true,

--- a/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-invites-endpoint.php
@@ -948,33 +948,33 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 				'title'      => 'bp_group_invites',
 				'type'       => 'object',
 				'properties' => array(
-					'id'            => array(
+					'id'                => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'A unique numeric ID for the BP Invitation object.', 'buddypress' ),
 						'type'        => 'integer',
 						'readonly'    => true,
 					),
-					'user_id'       => array(
+					'user_id'           => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The ID of the user who is invited to join the Group.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-					'invite_sent'   => array(
+					'invite_sent'       => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Whether the invite has been sent to the invitee.', 'buddypress' ),
 						'type'        => 'boolean',
 					),
-					'inviter_id'    => array(
+					'inviter_id'        => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The ID of the user who made the invite.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-					'group_id'      => array(
+					'group_id'          => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The ID of the group to which the user has been invited.', 'buddypress' ),
 						'type'        => 'integer',
 					),
-					'date_modified' => array(
+					'date_modified'     => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The date the object was created or last updated, in the site\'s timezone.', 'buddypress' ),
 						'readonly'    => true,
@@ -988,14 +988,14 @@ class BP_REST_Group_Invites_Endpoint extends WP_REST_Controller {
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'type'          => array(
+					'type'              => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Invitation or request.', 'buddypress' ),
 						'type'        => 'string',
 						'enum'        => array( 'invite', 'request' ),
 						'default'     => 'invite',
 					),
-					'message'       => array(
+					'message'           => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The raw and rendered versions for the content of the message.', 'buddypress' ),
 						'type'        => 'object',

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -1286,14 +1286,14 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'last_activity_gmt'      => array(
+					'last_activity_gmt'  => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The date the Group was last active, as GMT.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'last_activity_diff'  => array(
+					'last_activity_diff' => array(
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'description' => __( 'The human diff time the Group was last active, in the site\'s timezone.', 'buddypress' ),
 						'type'        => 'string',

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -39,7 +39,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>[\d]+)',
 			array(
-				'args' => array(
+				'args'   => array(
 					'id' => array(
 						'description' => __( 'Unique identifier for the member.', 'buddypress' ),
 						'type'        => 'integer',
@@ -855,13 +855,13 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 				'title'      => 'bp_members',
 				'type'       => 'object',
 				'properties' => array(
-					'id'                 => array(
+					'id'                     => array(
 						'description' => __( 'A unique numeric ID for the Member.', 'buddypress' ),
 						'type'        => 'integer',
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
-					'name'               => array(
+					'name'                   => array(
 						'description' => __( 'Display name for the member.', 'buddypress' ),
 						'type'        => 'string',
 						'context'     => array( 'view', 'edit' ),
@@ -869,7 +869,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
-					'mention_name'       => array(
+					'mention_name'           => array(
 						'description' => __( 'The name used for that user in @-mentions.', 'buddypress' ),
 						'type'        => 'string',
 						'context'     => array( 'view', 'edit', 'embed' ),
@@ -878,14 +878,14 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						),
 						'readonly'    => true,
 					),
-					'link'               => array(
+					'link'                   => array(
 						'description' => __( 'Profile URL of the member.', 'buddypress' ),
 						'type'        => 'string',
 						'format'      => 'uri',
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
-					'user_login'         => array(
+					'user_login'             => array(
 						'description' => __( 'An alphanumeric identifier for the Member.', 'buddypress' ),
 						'type'        => 'string',
 						'context'     => array( 'view', 'edit', 'embed' ),
@@ -894,7 +894,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 							'sanitize_callback' => array( $this, 'check_username' ),
 						),
 					),
-					'member_types'       => array(
+					'member_types'           => array(
 						'description' => __( 'Member types associated with the member.', 'buddypress' ),
 						'enum'        => bp_get_member_types(),
 						'type'        => 'array',
@@ -904,27 +904,27 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'readonly'    => true,
 					),
-					'registered_date'    => array(
+					'registered_date'        => array(
 						'description' => __( 'Registration date for the member, in the site\'s timezone.', 'buddypress' ),
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 						'context'     => array( 'edit' ),
 						'readonly'    => true,
 					),
-					'registered_date_gmt' => array(
+					'registered_date_gmt'    => array(
 						'description' => __( 'Registration date for the member, as GMT.', 'buddypress' ),
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 						'context'     => array( 'edit' ),
 						'readonly'    => true,
 					),
-					'registered_since'   => array(
+					'registered_since'       => array(
 						'description' => __( 'Elapsed time since the member registered.', 'buddypress' ),
 						'type'        => 'string',
 						'context'     => array( 'view', 'edit' ),
 						'readonly'    => true,
 					),
-					'password'           => array(
+					'password'               => array(
 						'description' => __( 'Password for the member (never included).', 'buddypress' ),
 						'type'        => 'string',
 						'context'     => array(), // Password is never displayed.
@@ -933,7 +933,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 							'sanitize_callback' => array( $this, 'check_user_password' ),
 						),
 					),
-					'roles'              => array(
+					'roles'                  => array(
 						'description' => __( 'Roles assigned to the member.', 'buddypress' ),
 						'type'        => 'array',
 						'context'     => array( 'edit' ),
@@ -941,25 +941,25 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 							'type' => 'string',
 						),
 					),
-					'capabilities'       => array(
+					'capabilities'           => array(
 						'description' => __( 'All capabilities assigned to the user.', 'buddypress' ),
 						'type'        => 'object',
 						'context'     => array( 'edit' ),
 						'readonly'    => true,
 					),
-					'extra_capabilities' => array(
+					'extra_capabilities'     => array(
 						'description' => __( 'Any extra capabilities assigned to the user.', 'buddypress' ),
 						'type'        => 'object',
 						'context'     => array( 'edit' ),
 						'readonly'    => true,
 					),
-					'xprofile'             => array(
+					'xprofile'               => array(
 						'description' => __( 'Member XProfile groups and its fields.', 'buddypress' ),
 						'type'        => 'array',
 						'context'     => array( 'view', 'edit' ),
 						'readonly'    => true,
 					),
-					'friendship_status'    => array(
+					'friendship_status'      => array(
 						'description' => __( 'Friendship relation with, current, logged in user.', 'buddypress' ),
 						'type'        => 'bool',
 						'context'     => array( 'view', 'edit', 'embed' ),
@@ -987,7 +987,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 								'readonly'    => true,
 								'format'      => 'date-time',
 							),
-							'date_gmt'  => array(
+							'date_gmt' => array(
 								'description' => __( 'Date as GMT.', 'buddypress' ),
 								'type'        => array( 'string', 'null' ),
 								'readonly'    => true,

--- a/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
@@ -902,7 +902,7 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 						'readonly'    => true,
 						'format'      => 'date-time',
 					),
-					'registered_gmt'     => array(
+					'registered_gmt' => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The registered date for the user, as GMT.', 'buddypress' ),
 						'type'        => array( 'string', 'null' ),
@@ -916,7 +916,7 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 						'readonly'    => true,
 						'format'      => 'date-time',
 					),
-					'date_sent_gmt'      => array(
+					'date_sent_gmt'  => array(
 						'context'     => array( 'edit' ),
 						'description' => __( 'The date the activation email was sent to the user, as GMT.', 'buddypress' ),
 						'type'        => array( 'string', 'null' ),

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -1269,14 +1269,14 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 							),
 						),
 					),
-					'date'            => array(
+					'date'                => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Dat of the latest message of the Thread, in the site\'s timezone.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'date_gmt'        => array(
+					'date_gmt'            => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Dat of the latest message of the Thread, as GMT.', 'buddypress' ),
 						'readonly'    => true,

--- a/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-sitewide-notices-endpoint.php
@@ -55,7 +55,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>[\d]+)',
 			array(
-				'args' => array(
+				'args'   => array(
 					'id' => array(
 						'description' => __( 'A unique numeric ID for the Sitewide notice.', 'buddypress' ),
 						'type'        => 'integer',
@@ -873,7 +873,7 @@ class BP_REST_Sitewide_Notices_Endpoint extends WP_REST_Controller {
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 					),
-					'date_gmt'      => array(
+					'date_gmt'  => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The date of the sitewide notice, as GMT.', 'buddypress' ),
 						'readonly'    => true,

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -534,25 +534,25 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 				'title'      => 'bp_xprofile_data',
 				'type'       => 'object',
 				'properties' => array(
-					'id'           => array(
+					'id'               => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'A unique numeric ID for the profile data.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
-					'field_id'     => array(
+					'field_id'         => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The ID of the field the data is from.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
-					'user_id'      => array(
+					'user_id'          => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The ID of the user the field data is from.', 'buddypress' ),
 						'readonly'    => true,
 						'type'        => 'integer',
 					),
-					'value'        => array(
+					'value'            => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The value of the field data.', 'buddypress' ),
 						'type'        => 'object',
@@ -583,7 +583,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 							),
 						),
 					),
-					'last_updated' => array(
+					'last_updated'     => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'The date the field data was last updated, in the site\'s timezone.', 'buddypress' ),
 						'readonly'    => true,

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -69,7 +69,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
-						'user_id' => array(
+						'user_id'          => array(
 							'description'       => __( 'Required if you want to load a specific user\'s data.', 'buddypress' ),
 							'default'           => 0,
 							'type'              => 'integer',
@@ -766,7 +766,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'collection' => array(
 				'href' => rest_url( $base ),
 			),
-			'group' => array(
+			'group'      => array(
 				'href'       => rest_url( $group_base . $field->group_id ),
 				'embeddable' => true,
 			),
@@ -1058,7 +1058,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 						'type'        => 'string',
 						'enum'        => array_keys( bp_xprofile_get_visibility_levels() ),
 					),
-					'options'  => array(
+					'options'           => array(
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Options of the profile field.', 'buddypress' ),
 						'type'        => 'array',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -42,18 +42,18 @@
 			"dev": true
 		},
 		"@szmarczak/http-timer": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-			"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 			"dev": true,
 			"requires": {
 				"defer-to-connect": "^2.0.0"
 			}
 		},
 		"@types/cacheable-request": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-			"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
 			"dev": true,
 			"requires": {
 				"@types/http-cache-semantics": "*",
@@ -63,24 +63,24 @@
 			}
 		},
 		"@types/http-cache-semantics": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
 			"dev": true
 		},
 		"@types/keyv": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-			"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
+			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/node": {
-			"version": "14.14.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-			"integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+			"version": "16.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+			"integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
 			"dev": true
 		},
 		"@types/responselike": {
@@ -93,9 +93,9 @@
 			}
 		},
 		"@wordpress/env": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.0.0.tgz",
-			"integrity": "sha512-e/86uoT15PigMGEOyblLQX1/CzR+ruNxuzy6iCTFmcw0VllNHFJteOWJjd9MVo8AhhDg89KK2sTQ8GmM3lXSLw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.1.2.tgz",
+			"integrity": "sha512-ODeBOAcgmT3a7YmfCkVlcBonnUQQcZHiByH6zjtrertVkIA2JiajOqm1l7ru8VmRpIg1rZDlkUGivspp3tt3fg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
@@ -113,26 +113,26 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
 			"dev": true,
 			"requires": {
-				"type-fest": "^0.11.0"
+				"type-fest": "^0.21.3"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
 		},
 		"ansi-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -154,9 +154,9 @@
 			}
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -176,9 +176,9 @@
 			"dev": true
 		},
 		"buffer-from": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
 		"cacheable-lookup": {
@@ -192,9 +192,9 @@
 			}
 		},
 		"cacheable-request": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-			"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
 			"dev": true,
 			"requires": {
 				"clone-response": "^1.0.2",
@@ -202,7 +202,7 @@
 				"http-cache-semantics": "^4.0.0",
 				"keyv": "^4.0.0",
 				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
+				"normalize-url": "^6.0.1",
 				"responselike": "^2.0.0"
 			}
 		},
@@ -213,9 +213,9 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
@@ -238,9 +238,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-			"integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+			"integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
 			"dev": true
 		},
 		"cli-width": {
@@ -363,9 +363,9 @@
 			"dev": true
 		},
 		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
 		"debug": {
@@ -518,9 +518,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -647,9 +647,9 @@
 			"dev": true
 		},
 		"keyv": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-			"integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
+			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
 			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.1"
@@ -787,9 +787,9 @@
 			"dev": true
 		},
 		"normalize-url": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 			"dev": true
 		},
 		"once": {
@@ -845,9 +845,9 @@
 			"dev": true
 		},
 		"p-cancelable": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
-			"integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"dev": true
 		},
 		"p-event": {
@@ -994,9 +994,9 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "6.6.6",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-			"integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+			"version": "6.6.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -1021,15 +1021,15 @@
 			"dev": true
 		},
 		"signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
 			"dev": true
 		},
 		"simple-git": {
-			"version": "2.37.0",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.37.0.tgz",
-			"integrity": "sha512-ZK6qRnP+Xa2v23UEZDNHUfzswsuNCDHOQpWZRkpqNaXn7V5wVBBx3zRJLji3pROJGzrzA7mXwY7preL5EKuAaQ==",
+			"version": "2.47.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.47.0.tgz",
+			"integrity": "sha512-+HfCpqPBEZTPWiW9fPdbiPJDslM22MLqrktfzNKyI2pWaJa6DhfNVx4Mds04KZzVv5vjC9/ksw3y5gVf8ECWDg==",
 			"dev": true,
 			"requires": {
 				"@kwsites/file-exists": "^1.1.1",
@@ -1061,14 +1061,14 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"strip-ansi": "^6.0.1"
 			}
 		},
 		"string_decoder": {
@@ -1081,12 +1081,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^5.0.0"
+				"ansi-regex": "^5.0.1"
 			}
 		},
 		"supports-color": {
@@ -1099,9 +1099,9 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0",
@@ -1260,9 +1260,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yargs": {
@@ -1325,9 +1325,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "15.0.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-			"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,15 @@
     "plugin"
   ],
   "devDependencies": {
-    "@wordpress/env": "^4.0.0"
+    "@wordpress/env": "^4.1.2"
   },
   "engines": {
     "node": ">=14.15.0",
     "npm": ">=6.14.8"
   },
   "scripts": {
+    "preinstall": "npx check-node-version --package",
+    "prewp-env": "npx check-node-version --package",
     "wp-env": "wp-env",
     "phpunit": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/BP-REST/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/BP-REST/phpunit.xml.dist'",
     "phpunit:mu": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/BP-REST/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/BP-REST/tests/multisite.xml'"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Check against minimum WP version. -->
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="minimum_supported_wp_version" value="5.4"/>
 
 	<!--
 	Pass some flags to PHPCS:
@@ -20,9 +20,6 @@
 	s flag: Show sniff codes in all reports.
 	-->
 	<arg value="ps" />
-
-	<!-- Enable colors in report -->
-	<arg name="colors"/>
 
 	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
 	<arg name="cache" value=".phpcs/cache.json" />
@@ -44,10 +41,5 @@
 				<element value="buddypress" />
 			</property>
 		</properties>
-	</rule>
-
-	<!-- Allow array disalignment -->
-	<rule ref="WordPress">
-		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned"/>
 	</rule>
 </ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,9 @@
 // Use WP PHPUnit.
 require_once dirname( dirname( __FILE__ ) ) . '/vendor/wp-phpunit/wp-phpunit/__loaded.php';
 
+// Setting PHPUnit polyfills.
+const WP_TESTS_PHPUNIT_POLYFILLS_PATH = __DIR__ . '/../vendor/yoast/phpunit-polyfills';
+
 // Define constants.
 require( dirname( __FILE__ ) . '/define-constants.php' );
 


### PR DESCRIPTION
- Upgrading the `wp-env` package
- `yoast/phpunit-polyfills` introduced
- `wp-phpunit/wp-phpunit` upgraded to `5.8`
- Updating `package.json` to check current node version before moving forward.
- Fixing the last PHPCS issue
- Updating readme.md
- Updating WordPress version (related https://buddypress.trac.wordpress.org/ticket/8571)