### PR TITLE
XProfile Data: changing value type to a `string` instead of an `array`

### DIFF
--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-data-endpoint.php
@@ -70,7 +70,7 @@ class BP_REST_XProfile_Data_Endpoint extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => array(
 						'value' => array(
-							'description'       => __( 'The value(s) for the field data.', 'buddypress' ),
+							'description'       => __( 'The value(s) (comma separated list of values needs to be used in case of multiple values) for the field data.', 'buddypress' ),
 							'required'          => true,
 							'type'              => 'string',
 							'validate_callback' => 'rest_validate_request_arg',


### PR DESCRIPTION
fixes #424 

I'm suggesting we change the `value` type from an `array` into a `string`. The current behavior using an `array` is changing the output from `Option 01` into `["Option", "01"]`. Solving this for all use cases is tricky.

Instead of an `array` people would set the value as `Option 01,Option 02` which would be translated to an `array` in the REST API. This also would work for both single fields and fields with multiple options.

Other fixes:

- Unit tests support for the XProfile data update improved
- Clearing selected items of a field was introduced (a bug)
- Saving an option that a field does not have in its list of options returns an error