### PR TITLE
Bump plugin version to 0.7

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -5,10 +5,10 @@
  * Description: BuddyPress extension for WordPress' JSON-based REST API.
  * Author: The BuddyPress Community
  * Author URI: https://buddypress.org/
- * Version: 0.6.0
+ * Version: 0.7.0
  * Text Domain: buddypress
- * Requires at least: 4.9
- * Tested up to: 5.6
+ * Requires at least: 5.4
+ * Tested up to: 5.9
  * Requires PHP: 5.6
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:       https://buddypress.org
 Requires at least: 4.9
 Tested up to:      5.6
 Requires PHP:      5.6
-Stable tag:        0.6.0
+Stable tag:        0.7.0
 License:           GPLv2
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,6 +20,9 @@ Access your BuddyPress site's data through an easy-to-use HTTP REST API.
 2. Activate BP-REST through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+
+= 0.6.0 =
+* Inclusion in BuddyPress 10.0.0
 
 = 0.5.0 =
 * Inclusion in BuddyPress 9.0.0


### PR DESCRIPTION
0.7 will be included into BuddyPress 11.0.0

I've just created the [0.6](https://github.com/buddypress/BP-REST/tree/0.6) branch to use it into the BuddyPress 10.0 branch Grunt file.