### PR TITLE
Components: check if the `core` component is in the `array`

### DIFF
--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -99,7 +99,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 
 		// Core component is always active.
 		if ( 'optional' !== $type && ! empty( $components['core'] ) ) {
-			$active_components['core'] = $components['core'];
+			$active_components['core'] = '1';
 		}
 
 		// Inactive components.
@@ -108,7 +108,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 		$current_components = array();
 		switch ( $args['status'] ) {
 			case 'all':
-				foreach ( $components as $name => $labels ) {
+				foreach ( array_keys( $components ) as $name ) {
 					$current_components[] = $this->get_component_info( $name );
 				}
 				break;

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -95,7 +95,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 		$components = bp_core_get_components( $type );
 
 		// Active components.
-		$active_components = apply_filters( 'bp_active_components', bp_get_option( 'bp-active-components' ) );
+		$active_components = (array) apply_filters( 'bp_active_components', bp_get_option( 'bp-active-components' ) );
 
 		// Core component is always active.
 		if ( 'optional' !== $type && ! empty( $components['core'] ) ) {

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -159,7 +159,6 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {
-		return true;
 		$retval = new WP_Error(
 			'bp_rest_authorization_required',
 			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),

--- a/includes/bp-components/classes/class-bp-rest-components-endpoint.php
+++ b/includes/bp-components/classes/class-bp-rest-components-endpoint.php
@@ -98,7 +98,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 		$active_components = apply_filters( 'bp_active_components', bp_get_option( 'bp-active-components' ) );
 
 		// Core component is always active.
-		if ( 'optional' !== $type ) {
+		if ( 'optional' !== $type && ! empty( $components['core'] ) ) {
 			$active_components['core'] = $components['core'];
 		}
 
@@ -159,6 +159,7 @@ class BP_REST_Components_Endpoint extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {
+		return true;
 		$retval = new WP_Error(
 			'bp_rest_authorization_required',
 			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),


### PR DESCRIPTION
As titled.

Bug reported here: https://buddypress.org/support/topic/fatal-error-after-updating-to-php-8-0/