### PR TITLE
Add the `embed` context to the `name`’s members endpoint schema property

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -943,7 +943,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 					'name'                   => array(
 						'description' => __( 'Display name for the member.', 'buddypress' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'arg_options' => array(
 							'sanitize_callback' => 'sanitize_text_field',
 						),


### PR DESCRIPTION
To get the Activity Author's display name, when making an `activity/?_embed=true` request, we need to add the `embed` context to the `name` property of the members endpoint schema.

Fixes #458