### PR TITLE
Thread: update recipients `array`

### DIFF
--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -959,7 +959,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 
 		// Loop through recipients to prepare them for the response.
 		foreach ( $thread->recipients as $recipient ) {
-			$data['recipients'][ $recipient->user_id ] = $this->prepare_recipient_for_response( $recipient, $request );
+			$data['recipients'][] = $this->prepare_recipient_for_response( $recipient, $request );
 		}
 
 		// Pluck starred message ids.


### PR DESCRIPTION
Make sure we return a proper `array` so that the output is consistent with the rest of the endpoints.