### PR TITLE
Implement the `BP_REST_Members_Endpoint::delete_current_item()` method

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -449,7 +449,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 		}
 
 		$previous = $this->prepare_item_for_response( $user, $request );
-		$result   = bp_core_delete_account();;
+		$result   = bp_core_delete_account();
 
 		if ( ! $result ) {
 			return new WP_Error(

--- a/tests/testcases/members/test-controller.php
+++ b/tests/testcases/members/test-controller.php
@@ -811,6 +811,30 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
+	/**
+	 * @group delete_item
+	 */
+	public function test_delete_current_item() {
+		$u = $this->factory->user->create( array( 'display_name' => 'Deleted User' ) );
+		$current_user = get_current_user_id();
+		$this->bp->set_current_user( $u );
+
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint_url . '/me' );
+		$request->set_param( 'force', true );
+		$request->set_param( 'reassign', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertTrue( $data['deleted'] );
+		$this->assertEquals( 'Deleted User', $data['previous']['name'] );
+
+		$this->bp->set_current_user( $u );
+	}
+
 	public function test_prepare_item() {
 		$this->bp->set_current_user( self::$user );
 


### PR DESCRIPTION
This is a follow up of https://buddypress.trac.wordpress.org/ticket/8758

After more research, we haven't implemented this method yet. WordPress is kind of "faking" this method as it requires the user to have the `delete_users` capability which regular users don't. As we allow users to delete their account from the front-end, we should also allow users to delete their account using the BP REST API.

Ideally, I'd like this to be committed before we release BuddyPress 11.0.0 (~ December 14)