### PR TITLE
Adds a new collection parameter to include a list of profile fields groups

### DIFF
--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -166,9 +166,9 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			$args['exclude_groups'] = false;
 		}
 
-		$include_groups = $request->get_param( 'include_groups' );
-		if ( $include_groups && ! $args['profile_group_id'] ) {
-			$args['profile_group_id'] = $include_groups;
+		$include = $request->get_param( 'include' );
+		if ( $include && ! $args['profile_group_id'] ) {
+			$args['profile_group_id'] = $include;
 		}
 
 		/**
@@ -866,12 +866,12 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$params['include_groups'] = array(
+		$params['include'] = array(
 			'description'       => __( 'Ensure result set inludes specific profile field groups.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => 'bp_rest_sanitize_string_list',
+			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
@@ -880,7 +880,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'default'           => array(),
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => 'bp_rest_sanitize_string_list',
+			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -166,9 +166,9 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			$args['exclude_groups'] = false;
 		}
 
-		$include = $request->get_param( 'include' );
-		if ( $include && ! $args['profile_group_id'] ) {
-			$args['profile_group_id'] = $include;
+		$include_groups = $request->get_param( 'include_groups' );
+		if ( $include_groups && ! $args['profile_group_id'] ) {
+			$args['profile_group_id'] = $include_groups;
 		}
 
 		/**
@@ -866,7 +866,7 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$params['include'] = array(
+		$params['include_groups'] = array(
 			'description'       => __( 'Ensure result set inludes specific profile field groups.', 'buddypress' ),
 			'default'           => array(),
 			'type'              => 'array',

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -166,6 +166,11 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			$args['exclude_groups'] = false;
 		}
 
+		$include_groups = $request->get_param( 'include_groups' );
+		if ( $include_groups && ! $args['profile_group_id'] ) {
+			$args['profile_group_id'] = $include_groups;
+		}
+
 		/**
 		 * Filter the query arguments for the request.
 		 *
@@ -858,6 +863,15 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 			'default'           => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['include_groups'] = array(
+			'description'       => __( 'Ensure result set inludes specific profile field groups.', 'buddypress' ),
+			'default'           => array(),
+			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
+			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -1179,7 +1179,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'default'           => array(),
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => 'bp_rest_sanitize_string_list',
+			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
@@ -1188,7 +1188,7 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'default'           => array(),
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => 'bp_rest_sanitize_string_list',
+			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-fields-endpoint.php
@@ -137,6 +137,11 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			$args['member_type'] = false;
 		}
 
+		$include_groups = $request->get_param( 'include_groups' );
+		if ( $include_groups && ! $args['profile_group_id'] ) {
+			$args['profile_group_id'] = $include_groups;
+		}
+
 		/**
 		 * Filter the query arguments for the request.
 		 *
@@ -1166,6 +1171,15 @@ class BP_REST_XProfile_Fields_Endpoint extends WP_REST_Controller {
 			'default'           => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['include_groups'] = array(
+			'description'       => __( 'Ensure result set inludes specific profile field groups.', 'buddypress' ),
+			'default'           => array(),
+			'type'              => 'array',
+			'items'             => array( 'type' => 'integer' ),
+			'sanitize_callback' => 'bp_rest_sanitize_string_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/tests/testcases/xprofile/test-field-controller.php
+++ b/tests/testcases/xprofile/test-field-controller.php
@@ -85,6 +85,34 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 	}
 
 	/**
+	 * @group get_items
+	 */
+	public function test_get_items_include_groups() {
+		$g1 = $this->bp_factory->xprofile_group->create();
+		$g2 = $this->bp_factory->xprofile_group->create();
+		$this->bp_factory->xprofile_field->create_many( 3, [ 'field_group_id' => $g1 ] );
+		$this->bp_factory->xprofile_field->create_many( 2, [ 'field_group_id' => $g2 ] );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'include_groups', array( $g2 ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->check_field_data(
+			$this->endpoint->get_xprofile_field_object( $data[0]['id'] ),
+			$data[0]
+		);
+
+		$this->assertEmpty( wp_filter_object_list( $data, array( 'group_id' => $g1 ) ) );
+		$this->assertTrue( 2 === count( wp_filter_object_list( $data, array( 'group_id' => $g2 ) ) ) );
+	}
+
+	/**
 	 * @group get_item
 	 */
 	public function test_get_item() {

--- a/tests/testcases/xprofile/test-group-controller.php
+++ b/tests/testcases/xprofile/test-group-controller.php
@@ -66,6 +66,37 @@ class BP_Test_REST_XProfile_Groups_Endpoint extends WP_Test_REST_Controller_Test
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_include_groups() {
+		$this->bp->set_current_user( $this->user );
+
+		$g1 = $this->bp_factory->xprofile_group->create();
+		$g2 = $this->bp_factory->xprofile_group->create();
+		$this->bp_factory->xprofile_group->create_many( 3 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'view' );
+		$request->set_param( 'include_groups', array( $g1, $g2 ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$all_data = $response->get_data();
+		$this->assertNotEmpty( $all_data );
+
+		foreach ( $all_data as $data ) {
+			$field_group = $this->endpoint->get_xprofile_field_group_object( $data['id'] );
+			$this->check_group_data( $field_group, $data, 'view', $response->get_links() );
+		}
+
+		$group_ids = wp_list_pluck( $all_data, 'id' );
+		sort( $group_ids );
+		$this->assertSame( $group_ids, array( $g1, $g2 ) );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_publicly() {
 		$this->bp_factory->xprofile_group->create_many( 5 );
 

--- a/tests/testcases/xprofile/test-group-controller.php
+++ b/tests/testcases/xprofile/test-group-controller.php
@@ -75,7 +75,7 @@ class BP_Test_REST_XProfile_Groups_Endpoint extends WP_Test_REST_Controller_Test
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
 		$request->set_param( 'context', 'view' );
-		$request->set_param( 'include', array( $g1, $g2 ) );
+		$request->set_param( 'include_groups', array( $g1, $g2 ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 

--- a/tests/testcases/xprofile/test-group-controller.php
+++ b/tests/testcases/xprofile/test-group-controller.php
@@ -75,7 +75,7 @@ class BP_Test_REST_XProfile_Groups_Endpoint extends WP_Test_REST_Controller_Test
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
 		$request->set_param( 'context', 'view' );
-		$request->set_param( 'include_groups', array( $g1, $g2 ) );
+		$request->set_param( 'include', array( $g1, $g2 ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 


### PR DESCRIPTION
The `profile_group_id` parameter of `BP_XProfile_Group::get()` now accepts (BuddyPress 11.0.0) an array of profile group ids. Instead of modifying the `profile_group_id` parameter of the collection params, I suggest to introduce an `include_groups` one.

See https://buddypress.trac.wordpress.org/changeset/13358/