### PR TITLE
Stop using `bp_core_get_user_domain()` function

### DIFF
--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -641,7 +641,7 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 
 		// Link.
 		if ( empty( $fields ) || ! empty( $fields['link'] ) ) {
-			$data['link'] = bp_core_get_user_domain( $user->ID, $user->user_nicename, $user->user_login );
+			$data['link'] = bp_members_get_user_url( $user->ID );
 		}
 
 		// Member types.

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -881,7 +881,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			'thread_id'    => (int) $recipient->thread_id,
 			'unread_count' => (int) $recipient->unread_count,
 			'user_id'      => (int) $recipient->user_id,
-			'user_link'    => esc_url( bp_core_get_user_domain( $recipient->user_id ) ),
+			'user_link'    => esc_url( bp_members_get_user_url( $recipient->user_id ) ),
 		);
 
 		// Fetch the user avatar urls (Full & thumb).

--- a/tests/testcases/members/test-controller.php
+++ b/tests/testcases/members/test-controller.php
@@ -881,7 +881,7 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'friendship_status', $data );
 		$this->assertArrayHasKey( 'friendship_status_slug', $data );
 		$this->assertEquals(
-			bp_core_get_user_domain( $data['id'], $user->user_nicename, $user->user_login ),
+			bp_members_get_user_url( $data['id'] ),
 			$data['link']
 		);
 

--- a/tests/testcases/membership/test-group-membership-controller.php
+++ b/tests/testcases/membership/test-group-membership-controller.php
@@ -956,7 +956,7 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 		$this->assertArrayHasKey( 'full', $data['avatar_urls'] );
 		$this->assertArrayHasKey( 'member_types', $data );
 		$this->assertEquals(
-			bp_core_get_user_domain( $data['id'], $user->user_nicename, $user->user_login ),
+			bp_members_get_user_url( $data['id'] ),
 			$data['link']
 		);
 

--- a/tests/testcases/messages/test-controller.php
+++ b/tests/testcases/messages/test-controller.php
@@ -1000,7 +1000,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		foreach( $recipients as $recipient ) {
 			$user_id = $recipient['user_id'];
-			$this->assertEquals( esc_url( bp_core_get_user_domain( $user_id ) ), $recipient['user_link'] );
+			$this->assertEquals( esc_url( bp_members_get_user_url( $user_id ) ), $recipient['user_link'] );
 
 			foreach ( array( 'full', 'thumb' ) as $type ) {
 				$expected['user_avatars'][ $type ] = bp_core_fetch_avatar(


### PR DESCRIPTION
This function was deprecated in BuddyPress 12.0 and replaced by `bp_members_get_user_url()`.

See #479