### PR TITLE
Use BP Rewrites ready functions to get blog/group links

### DIFF
--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -526,7 +526,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 		}
 
 		if ( empty( $blog->domain ) && ! empty( $blog->path ) ) {
-			return bp_get_root_domain() . $blog->path;
+			return bp_get_root_url() . $blog->path;
 		}
 
 		$protocol  = is_ssl() ? 'https://' : 'http://';

--- a/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-groups-endpoint.php
@@ -726,7 +726,7 @@ class BP_REST_Groups_Endpoint extends WP_REST_Controller {
 				'rendered' => bp_get_group_description( $item ),
 			),
 			'enable_forum'       => bp_group_is_forum_enabled( $item ),
-			'link'               => bp_get_group_permalink( $item ),
+			'link'               => bp_get_group_url( $item ),
 			'name'               => bp_get_group_name( $item ),
 			'slug'               => bp_get_group_slug( $item ),
 			'status'             => bp_get_group_status( $item ),

--- a/tests/testcases/groups/test-controller.php
+++ b/tests/testcases/groups/test-controller.php
@@ -1078,7 +1078,7 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		);
 		$this->assertEquals( bp_rest_prepare_date_response( $group->date_created ), $data['date_created_gmt'] );
 		$this->assertEquals( $group->enable_forum, $data['enable_forum'] );
-		$this->assertEquals( bp_get_group_permalink( $group ), $data['link'] );
+		$this->assertEquals( bp_get_group_url( $group ), $data['link'] );
 		$this->assertEquals( $group->name, $data['name'] );
 		$this->assertEquals( $group->slug, $data['slug'] );
 		$this->assertEquals( $group->status, $data['status'] );


### PR DESCRIPTION
- Replace `bp_get_root_domain()` in favor of `bp_get_root_url()`
- Replace `bp_get_group_permalink()` in favor of `bp_get_group_url()`

See #479 