### PR TITLE
Update GH PHPUnit action raising WP version to 6.2

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,9 +16,9 @@ jobs:
         wp_version: ['master']
         include:
           - php: '8.0'
-            wp_version: '6.1'
+            wp_version: '6.2'
           - php: '7.4'
-            wp_version: '6.1'
+            wp_version: '6.2'
           - php: '7.4'
             wp_version: '5.8'
     env:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "require-dev": {
     "buddypress/bp-coding-standards": "dev-trunk",
-    "wp-phpunit/wp-phpunit": "^6.1",
+    "wp-phpunit/wp-phpunit": "^6.2",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "scripts": {


### PR DESCRIPTION
- Update composer.json file to use wp-phpunit 6.2