### PR TITLE
Make sure the Message rendered subject uses WP Emojis

### DIFF
--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -828,11 +828,11 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			'sender_id' => (int) $message->sender_id,
 			'subject'   => array(
 				'raw'      => $message->subject,
-				'rendered' => apply_filters( 'bp_get_message_thread_subject', wp_staticize_emoji( $message->subject ) ),
+				'rendered' => apply_filters( 'bp_get_message_thread_subject', $message->subject ),
 			),
 			'message'   => array(
 				'raw'      => $message->message,
-				'rendered' => apply_filters( 'bp_get_the_thread_message_content', wp_staticize_emoji( $message->message ) ),
+				'rendered' => apply_filters( 'bp_get_the_thread_message_content', $message->message ),
 			),
 			'date_sent' => bp_rest_prepare_date_response( $message->date_sent ),
 		);
@@ -930,7 +930,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			'last_sender_id' => (int) $thread->last_sender_id,
 			'subject'        => array(
 				'raw'      => $thread->last_message_subject,
-				'rendered' => apply_filters( 'bp_get_message_thread_subject', wp_staticize_emoji( $thread->last_message_subject ) ),
+				'rendered' => apply_filters( 'bp_get_message_thread_subject', $thread->last_message_subject ),
 			),
 			'excerpt'        => array(
 				'raw'      => $excerpt,
@@ -938,7 +938,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			),
 			'message'        => array(
 				'raw'      => $thread->last_message_content,
-				'rendered' => apply_filters( 'bp_get_message_thread_content', wp_staticize_emoji( $thread->last_message_content ) ),
+				'rendered' => apply_filters( 'bp_get_message_thread_content',$thread->last_message_content ),
 			),
 			'date'           => bp_rest_prepare_date_response( $thread->last_message_date, get_date_from_gmt( $thread->last_message_date ) ),
 			'date_gmt'       => bp_rest_prepare_date_response( $thread->last_message_date ),

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -938,7 +938,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			),
 			'message'        => array(
 				'raw'      => $thread->last_message_content,
-				'rendered' => apply_filters( 'bp_get_message_thread_content',$thread->last_message_content ),
+				'rendered' => apply_filters( 'bp_get_message_thread_content', $thread->last_message_content ),
 			),
 			'date'           => bp_rest_prepare_date_response( $thread->last_message_date, get_date_from_gmt( $thread->last_message_date ) ),
 			'date_gmt'       => bp_rest_prepare_date_response( $thread->last_message_date ),

--- a/tests/testcases/messages/test-controller.php
+++ b/tests/testcases/messages/test-controller.php
@@ -1062,8 +1062,8 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( $thread->thread_id, $data['id'] );
 		$this->assertEquals( $thread->last_message_id, $data['message_id'] );
 		$this->assertEquals( $thread->last_sender_id, $data['last_sender_id'] );
-		$this->assertEquals( apply_filters( 'bp_get_message_thread_subject', wp_staticize_emoji( $thread->last_message_subject ) ), $data['subject']['rendered'] );
-		$this->assertEquals( apply_filters( 'bp_get_message_thread_content', wp_staticize_emoji( $thread->last_message_content ) ), $data['message']['rendered'] );
+		$this->assertEquals( apply_filters( 'bp_get_message_thread_subject', $thread->last_message_subject ), $data['subject']['rendered'] );
+		$this->assertEquals( apply_filters( 'bp_get_message_thread_content', $thread->last_message_content ), $data['message']['rendered'] );
 		$this->assertEquals(
 			bp_rest_prepare_date_response( $thread->last_message_date, get_date_from_gmt( $thread->last_message_date ) ),
 			$data['date']


### PR DESCRIPTION
Instead of applying `wp_staticize_emoji` to subject and content which was ending up being stripped by the `wp_filter_kses` callback applied to the message subject template, move `wp_staticize_emoji` use inside BuddyPress core as a Messages filter.

See https://github.com/buddypress/buddypress/pull/123

Fixes #485