### PR TITLE
XProfile field: test string with apostrophes is handled correctly in a field update

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "core": "WordPress/WordPress#master",
-  "plugins": ["buddypress/buddypress#feature/9127", "."],
+  "plugins": ["buddypress/buddypress#master", "."],
   "config": {
     "WP_DEBUG": true,
     "SCRIPT_DEBUG": true

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "core": "WordPress/WordPress#master",
-  "plugins": ["buddypress/buddypress#master", "."],
+  "plugins": ["buddypress/buddypress#feature/9127", "."],
   "config": {
     "WP_DEBUG": true,
     "SCRIPT_DEBUG": true

--- a/tests/testcases/xprofile/test-data-controller.php
+++ b/tests/testcases/xprofile/test-data-controller.php
@@ -283,6 +283,108 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 
 	/**
 	 * @group update_item
+	 *
+	 * @ticket https://buddypress.trac.wordpress.org/ticket/9127
+	 */
+	public function test_update_multiselectbox_with_apostrophe_value() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'multiselectbox',
+				'field_group_id' => $this->group_id
+			]
+		);
+		xprofile_insert_field(
+			[
+				'field_group_id' => $this->group_id,
+				'parent_id'      => $field_id,
+				'type'           => 'option',
+				'name'           => 'Option 1',
+			]
+		);
+
+		xprofile_insert_field(
+			[
+				'field_group_id' => $this->group_id,
+				'parent_id'      => $field_id,
+				'type'           => 'option',
+				'name'           => "I don't travel often",
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => "I don\'t travel often" ] );
+
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( $data[0]['value']['unserialized'], [ "I don\'t travel often" ] );
+		$this->assertEquals( $data[0]['value']['raw'], "a:1:{i:0;s:21:\"I don\\'t travel often\";}" );
+	}
+
+	/**
+	 * @group update_item
+	 *
+	 * @ticket https://buddypress.trac.wordpress.org/ticket/9127
+	 */
+	public function test_update_checkbox_with_apostrophe_value() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'checkbox',
+				'field_group_id' => $this->group_id
+			]
+		);
+		xprofile_insert_field(
+			[
+				'field_group_id' => $this->group_id,
+				'parent_id'      => $field_id,
+				'type'           => 'option',
+				'name'           => 'Option 1',
+			]
+		);
+
+		xprofile_insert_field(
+			[
+				'field_group_id' => $this->group_id,
+				'parent_id'      => $field_id,
+				'type'           => 'option',
+				'name'           => "I don't travel often",
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => "I don\'t travel often" ] );
+
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data );
+
+		$this->assertEquals( $data[0]['value']['unserialized'], [ "I don\'t travel often" ] );
+		$this->assertEquals( $data[0]['value']['raw'], "a:1:{i:0;s:21:\"I don\\'t travel often\";}" );
+	}
+
+	/**
+	 * @group update_item
 	 */
 	public function test_update_textbox() {
 		$field_id = $this->bp_factory->xprofile_field->create(

--- a/tests/testcases/xprofile/test-data-controller.php
+++ b/tests/testcases/xprofile/test-data-controller.php
@@ -314,6 +314,49 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 
 	/**
 	 * @group update_item
+	 *
+	 * @ticket https://buddypress.trac.wordpress.org/ticket/9127
+	 */
+	public function test_update_textbox_with_apostrophe_value() {
+		$field_id = $this->bp_factory->xprofile_field->create(
+			[
+				'type'           => 'textbox',
+				'field_group_id' => $this->group_id,
+				'value'          => 'textbox field',
+			]
+		);
+
+		$this->bp->set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => "I don't travel often" ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+		$this->assertEquals( $data[0]['value']['raw'], "I don't travel often" );
+
+		$request = new WP_REST_Request( 'POST', sprintf( $this->endpoint_url . '%d/data/%d', $field_id, $this->user ) );
+		$request->add_header( 'content-type', 'application/json' );
+
+		$params = $this->set_field_data( [ 'value' => "I don\\'t travel often" ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+		$this->assertEquals( $data[0]['value']['raw'], "I don't travel often" );
+	}
+
+	/**
+	 * @group update_item
 	 */
 	public function test_update_selectbox() {
 		$field_id = $this->bp_factory->xprofile_field->create(


### PR DESCRIPTION
Ticket: https://buddypress.trac.wordpress.org/ticket/9127

Applying this fix: https://github.com/buddypress/buddypress/pull/268