### PR TITLE
Messages: avoid a PHP Warning when getting a recipient's `display_name`

### DIFF
--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -875,8 +875,8 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 		$display_name = '';
 		$user_info    = get_userdata( (int) $recipient->user_id );
 
-		if ( $user_info instanceof WP_User ) {
-			$display_name = $user_info->display_name;
+		if ( $user_info instanceof WP_User && ! empty( $user_info->display_name ) ) {
+			$display_name = (string) $user_info->display_name;
 		}
 
 		$data      = array(

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -879,7 +879,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			$display_name = (string) $user_info->display_name;
 		}
 
-		$data      = array(
+		$data = array(
 			'id'           => (int) $recipient->id,
 			'is_deleted'   => (int) $recipient->is_deleted,
 			'name'         => $display_name,

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -872,11 +872,17 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 	 * @return array                     The recipient data for the REST response.
 	 */
 	public function prepare_recipient_for_response( $recipient, $request ) {
-		$user_info = get_userdata( (int) $recipient->user_id );
+		$display_name = '';
+		$user_info    = get_userdata( (int) $recipient->user_id );
+
+		if ( $user_info instanceof WP_User ) {
+			$display_name = $user_info->display_name;
+		}
+
 		$data      = array(
 			'id'           => (int) $recipient->id,
 			'is_deleted'   => (int) $recipient->is_deleted,
-			'name'         => (string) $user_info->display_name,
+			'name'         => $display_name,
 			'sender_only'  => (int) $recipient->sender_only,
 			'thread_id'    => (int) $recipient->thread_id,
 			'unread_count' => (int) $recipient->unread_count,


### PR DESCRIPTION
> PHP Warning: Attempt to read property "display_name" on bool in /wp-content/plugins/buddypress/bp-messages/classes/class-bp-rest-messages-endpoint.php on line 879.

If the user query fails, one can get this PHP warning even though it returns an empty string due to the PHP typecasting.

So let's avoid this one warning.

Tickets:
- https://buddypress.trac.wordpress.org/ticket/9127
- https://buddypress.trac.wordpress.org/ticket/9133