### PR TITLE
Fix a DB Error when BP Blogs component is active on a regular WP

### DIFF
--- a/bp-rest.php
+++ b/bp-rest.php
@@ -86,7 +86,7 @@ function bp_rest() {
 		$controller->register_routes();
 	}
 
-	if ( bp_is_active( 'blogs' ) ) {
+	if ( is_multisite() && bp_is_active( 'blogs' ) ) {
 		require_once dirname( __FILE__ ) . '/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php';
 		$controller = new BP_REST_Blogs_Endpoint();
 		$controller->register_routes();

--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -1149,7 +1149,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		}
 
 		// Embed Blog.
-		if ( bp_is_active( 'blogs' ) && buddypress()->blogs->id === $activity->component && ! empty( $activity->item_id ) ) {
+		if ( is_multisite() && bp_is_active( 'blogs' ) && buddypress()->blogs->id === $activity->component && ! empty( $activity->item_id ) ) {
 			$links['blog'] = array(
 				'embeddable' => true,
 				'href'       => rest_url(

--- a/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
+++ b/includes/bp-notifications/classes/class-bp-rest-notifications-endpoint.php
@@ -692,7 +692,7 @@ class BP_REST_Notifications_Endpoint extends WP_REST_Controller {
 		}
 
 		// Embed Blog.
-		if ( bp_is_active( 'blogs' ) && buddypress()->blogs->id === $notification->component_name && ! empty( $notification->item_id ) ) {
+		if ( is_multisite() && bp_is_active( 'blogs' ) && buddypress()->blogs->id === $notification->component_name && ! empty( $notification->item_id ) ) {
 			$links['blog'] = array(
 				'embeddable' => true,
 				'href'       => rest_url(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,8 @@
 	<testsuites>
 		<testsuite name="unit">
 			<directory prefix="test-" suffix=".php">./tests/testcases/</directory>
+			<exclude>tests/testcases/blogs/test-controller.php</exclude>
+			<exclude>tests/testcases/attachments/test-blog-avatar-controller.php</exclude>
 		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
Steps to reproduce the DB error:

- Use a regular WP config (not Multisite)
- Activate Activity component if not already active 
- Activate the Blogs component if not already active
- Publish a new post (it should generate a `new_blog_post` activity
- Go to `buddypress/v1/activity?_embed=1` 

You should get the DB Error, I believe you can also get it trying to get the root blog using the corresponding endpoint.

I believe it’s only impacting the BP REST plugin as the Blogs REST Controller is only loaded when Multisite is active and a stable BuddyPress release is used. See https://github.com/buddypress/buddypress/blob/ef9fde9191b87a2f6a4027f2ecc75cfc1c616090/src/bp-blogs/classes/class-bp-blogs-component.php#L508