### PR TITLE
Messages: add support for paginating thread messages

### DIFF
--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -239,14 +239,13 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			'recipients_per_page' => $request->get_param( 'recipients_per_page' ),
 			'page'                => $request->get_param( 'messages_page' ),
 			'per_page'            => $request->get_param( 'messages_per_page' ),
+			'order'               => $request->get_param( 'order' ),
+			'user_id'             => $request->get_param( 'user_id' ),
 		);
 
-		$user_id = bp_loggedin_user_id();
-		if ( ! empty( $request->get_param( 'user_id' ) ) ) {
-			$user_id = $request->get_param( 'user_id' );
+		if ( empty( $args['user_id'] ) ) {
+			$args['user_id'] = bp_loggedin_user_id();
 		}
-
-		$args['user_id'] = $user_id;
 
 		/**
 		 * Filter the query arguments for the request.
@@ -258,7 +257,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 
 		$thread = new BP_Messages_Thread(
 			$request->get_param( 'id' ),
-			$request->get_param( 'order' ),
+			'ASC', // not used.
 			$args
 		);
 
@@ -269,6 +268,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 		);
 
 		$response = rest_ensure_response( $retval );
+		$response = bp_rest_response_add_total_headers( $response, $thread->messages_total_count, $args['per_page'] );
 
 		/**
 		 * Fires after a thread is fetched via the REST API.

--- a/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
+++ b/includes/bp-messages/classes/class-bp-rest-messages-endpoint.php
@@ -12,8 +12,8 @@ defined( 'ABSPATH' ) || exit;
  * Messages endpoints.
  *
  * /messages/
- * /messages/{id}
  * /messages/{thread_id}
+ * /messages//starred{message_id}
  *
  * @since 0.1.0
  */
@@ -62,15 +62,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 			$this->namespace,
 			$thread_endpoint,
 			array(
-				'args'   => array(
-					'id' => array(
-						'description'       => __( 'ID of the thread.', 'buddypress' ),
-						'type'              => 'integer',
-						'required'          => true,
-						'sanitize_callback' => 'absint',
-						'validate_callback' => 'rest_validate_request_arg',
-					),
-				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
@@ -102,12 +93,6 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 				$this->namespace,
 				$starred_endpoint,
 				array(
-					'args'   => array(
-						'id' => array(
-							'description' => __( 'ID of one of the message of the Thread.', 'buddypress' ),
-							'type'        => 'integer',
-						),
-					),
 					array(
 						'methods'             => WP_REST_Server::EDITABLE,
 						'callback'            => array( $this, 'update_starred' ),
@@ -681,6 +666,7 @@ class BP_REST_Messages_Endpoint extends WP_REST_Controller {
 		);
 
 		if ( is_user_logged_in() ) {
+			// The id here is for the message id.
 			$thread_id = messages_get_message_thread_id( $request->get_param( 'id' ) );
 
 			if ( messages_check_thread_access( $thread_id ) ) {

--- a/tests/testcases/messages/test-controller.php
+++ b/tests/testcases/messages/test-controller.php
@@ -185,7 +185,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_item
 	 */
-	public function test_get_item_messages() {
+	public function test_get_thread_messages_paginated() {
 		$u1 = $this->factory->user->create();
 		$u2 = $this->factory->user->create();
 		$m  = $this->bp_factory->message->create_and_get( array(
@@ -193,6 +193,14 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 			'recipients' => array( $u2 ),
 			'subject'    => 'Foo',
 			'content'    => 'Content',
+		) );
+
+		// create several messages.
+		$this->bp_factory->message->create_many( 10, array(
+			'thread_id'  => $m->thread_id,
+			'sender_id'  => $u2,
+			'recipients' => array( $u1 ),
+			'content'    => 'Bar',
 		) );
 
 		// create a reply.
@@ -215,6 +223,7 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$all_data = current( $response->get_data() );
 
 		$this->assertCount( 1, $all_data['messages'] );
+		$this->assertSame( $m->thread_id, $all_data['messages'][0]['thread_id'] );
 		$this->assertSame( $message_id, $all_data['messages'][0]['id'] );
 	}
 

--- a/tests/testcases/messages/test-controller.php
+++ b/tests/testcases/messages/test-controller.php
@@ -220,6 +220,10 @@ class BP_Test_REST_Messages_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertEquals( 200, $response->get_status() );
 
+		$headers = $response->get_headers();
+		$this->assertEquals( 12, $headers['X-WP-Total'] );
+		$this->assertEquals( 12, $headers['X-WP-TotalPages'] );
+
 		$all_data = current( $response->get_data() );
 
 		$this->assertCount( 1, $all_data['messages'] );


### PR DESCRIPTION
Initially, at #429, we added support for message pagination while listing threads. In this pr, we add support when getting a single thread, and its messages.

fixes #409 
Ticket: https://buddypress.trac.wordpress.org/ticket/9146