### PR TITLE
Review the `bp_view` capability support in endpoints

### DIFF
--- a/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
+++ b/includes/bp-activity/classes/class-bp-rest-activity-endpoint.php
@@ -260,6 +260,17 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {
+		$retval = new WP_Error(
+			'bp_rest_authorization_required',
+			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'activity' ) ) ) {
+			$retval = true;
+		}
 
 		/**
 		 * Filter the activity `get_items` permissions check.
@@ -269,7 +280,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 		 * @param true|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request Full data about the request.
 		 */
-		return apply_filters( 'bp_rest_activity_get_items_permissions_check', true, $request );
+		return apply_filters( 'bp_rest_activity_get_items_permissions_check', $retval, $request );
 	}
 
 	/**
@@ -332,7 +343,7 @@ class BP_REST_Activity_Endpoint extends WP_REST_Controller {
 			)
 		);
 
-		if ( $this->can_see( $request ) ) {
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'activity' ) ) && $this->can_see( $request ) ) {
 			$retval = true;
 		}
 

--- a/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-attachments-blog-avatar-endpoint.php
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 6.0.0
  */
 class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
-
 	use BP_REST_Attachments;
 
 	/**
@@ -172,26 +171,24 @@ class BP_REST_Attachments_Blog_Avatar_Endpoint extends WP_REST_Controller {
 			)
 		);
 
-		$this->blog = $this->blogs_endpoint->get_blog_object( $request->get_param( 'id' ) );
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'blogs' ) ) ) {
+			$this->blog = $this->blogs_endpoint->get_blog_object( $request->get_param( 'id' ) );
 
-		if ( ! is_object( $this->blog ) ) {
-			$retval = new WP_Error(
-				'bp_rest_blog_invalid_id',
-				__( 'Invalid group ID.', 'buddypress' ),
-				array(
-					'status' => 404,
-				)
-			);
-		} elseif ( buddypress()->avatar->show_avatars ) {
-			$retval = true;
-		} else {
-			$retval = new WP_Error(
-				'bp_rest_attachments_blog_avatar_disabled',
-				__( 'Sorry, blog avatar is disabled.', 'buddypress' ),
-				array(
-					'status' => 500,
-				)
-			);
+			if ( ! is_object( $this->blog ) ) {
+				$retval = new WP_Error(
+					'bp_rest_blog_invalid_id',
+					__( 'Invalid group ID.', 'buddypress' ),
+					array( 'status' => 404 )
+				);
+			} elseif ( buddypress()->avatar->show_avatars ) {
+				$retval = true;
+			} else {
+				$retval = new WP_Error(
+					'bp_rest_attachments_blog_avatar_disabled',
+					__( 'Sorry, blog avatar is disabled.', 'buddypress' ),
+					array( 'status' => 500 )
+				);
+			}
 		}
 
 		/**

--- a/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
+++ b/includes/bp-blogs/classes/class-bp-rest-blogs-endpoint.php
@@ -165,6 +165,17 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {
+		$retval = new WP_Error(
+			'bp_rest_authorization_required',
+			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'blogs' ) ) ) {
+			$retval = true;
+		}
 
 		/**
 		 * Filter the blogs `get_items` permissions check.
@@ -174,7 +185,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 		 * @param true|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
 		 */
-		return apply_filters( 'bp_rest_blogs_get_items_permissions_check', true, $request );
+		return apply_filters( 'bp_rest_blogs_get_items_permissions_check', $retval, $request );
 	}
 
 	/**
@@ -229,6 +240,17 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_item_permissions_check( $request ) {
+		$retval = new WP_Error(
+			'bp_rest_authorization_required',
+			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'blogs' ) ) ) {
+			$retval = true;
+		}
 
 		/**
 		 * Filter the blog `get_item` permissions check.
@@ -238,7 +260,7 @@ class BP_REST_Blogs_Endpoint extends WP_REST_Controller {
 		 * @param true|WP_Error   $retval  Returned value.
 		 * @param WP_REST_Request $request The request sent to the API.
 		 */
-		return apply_filters( 'bp_rest_blogs_get_item_permissions_check', true, $request );
+		return apply_filters( 'bp_rest_blogs_get_item_permissions_check', $retval, $request );
 	}
 
 	/**

--- a/includes/bp-groups/classes/class-bp-rest-attachments-group-avatar-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-attachments-group-avatar-endpoint.php
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.1.0
  */
 class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
-
 	use BP_REST_Attachments;
 
 	/**
@@ -178,13 +177,12 @@ class BP_REST_Attachments_Group_Avatar_Endpoint extends WP_REST_Controller {
 		);
 
 		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'groups' ) ) ) {
-			$retval      = new WP_Error(
+			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
 				__( 'Invalid group ID.', 'buddypress' ),
-				array(
-					'status' => 404,
-				)
+				array( 'status' => 404 )
 			);
+
 			$this->group = $this->groups_endpoint->get_group_object( $request );
 
 			if ( false !== $this->group ) {

--- a/includes/bp-groups/classes/class-bp-rest-attachments-group-cover-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-attachments-group-cover-endpoint.php
@@ -16,7 +16,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 6.0.0
  */
 class BP_REST_Attachments_Group_Cover_Endpoint extends WP_REST_Controller {
-
 	use BP_REST_Attachments;
 
 	/**
@@ -167,9 +166,7 @@ class BP_REST_Attachments_Group_Cover_Endpoint extends WP_REST_Controller {
 			$retval = new WP_Error(
 				'bp_rest_group_invalid_id',
 				__( 'Invalid group ID.', 'buddypress' ),
-				array(
-					'status' => 404,
-				)
+				array( 'status' => 404 )
 			);
 
 			$this->group = $this->groups_endpoint->get_group_object( $request );

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-avatar-endpoint.php
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.1.0
  */
 class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
-
 	use BP_REST_Attachments;
 
 	/**
@@ -162,7 +161,7 @@ class BP_REST_Attachments_Member_Avatar_Endpoint extends WP_REST_Controller {
 	public function get_item_permissions_check( $request ) {
 		$retval = new WP_Error(
 			'bp_rest_authorization_required',
-			__( 'Sorry, you cannot view member details.', 'buddypress' ),
+			__( 'Sorry, you are not authorized to perform this action.', 'buddypress' ),
 			array(
 				'status' => rest_authorization_required_code(),
 			)

--- a/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-attachments-member-cover-endpoint.php
@@ -16,7 +16,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 6.0.0
  */
 class BP_REST_Attachments_Member_Cover_Endpoint extends WP_REST_Controller {
-
 	use BP_REST_Attachments;
 
 	/**
@@ -152,7 +151,7 @@ class BP_REST_Attachments_Member_Cover_Endpoint extends WP_REST_Controller {
 	public function get_item_permissions_check( $request ) {
 		$retval = new WP_Error(
 			'bp_rest_authorization_required',
-			__( 'Sorry, you cannot view member details.', 'buddypress' ),
+			__( 'Sorry, you are not authorized to perform this action.', 'buddypress' ),
 			array(
 				'status' => rest_authorization_required_code(),
 			)

--- a/includes/bp-members/classes/class-bp-rest-members-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-members-endpoint.php
@@ -201,7 +201,17 @@ class BP_REST_Members_Endpoint extends WP_REST_Users_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {
-		$retval = bp_current_user_can( 'bp_view', array( 'bp_component' => 'members' ) );
+		$retval = new WP_Error(
+			'bp_rest_authorization_required',
+			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'members' ) ) ) {
+			$retval = true;
+		}
 
 		/**
 		 * Filter the members `get_items` permissions check.

--- a/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
+++ b/includes/bp-members/classes/class-bp-rest-signup-endpoint.php
@@ -203,18 +203,16 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 			array( 'status' => rest_authorization_required_code() )
 		);
 
-		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'members' ) ) ) {
-			$capability = is_multisite() ? 'manage_network_users' : 'edit_users';
+		$capability = is_multisite() ? 'manage_network_users' : 'edit_users';
 
-			if ( ! is_user_logged_in() ) {
-				$retval = new WP_Error(
-					'bp_rest_authorization_required',
-					__( 'Sorry, you need to be logged in to perform this action.', 'buddypress' ),
-					array( 'status' => rest_authorization_required_code() )
-				);
-			} elseif ( bp_current_user_can( $capability ) ) {
-				$retval = true;
-			}
+		if ( ! is_user_logged_in() ) {
+			$retval = new WP_Error(
+				'bp_rest_authorization_required',
+				__( 'Sorry, you need to be logged in to perform this action.', 'buddypress' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		} elseif ( bp_current_user_can( $capability ) ) {
+			$retval = true;
 		}
 
 		/**
@@ -276,29 +274,27 @@ class BP_REST_Signup_Endpoint extends WP_REST_Controller {
 			array( 'status' => rest_authorization_required_code() )
 		);
 
-		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'members' ) ) ) {
-			$capability = is_multisite() ? 'manage_network_users' : 'edit_users';
+		$capability = is_multisite() ? 'manage_network_users' : 'edit_users';
 
-			if ( ! is_user_logged_in() ) {
+		if ( ! is_user_logged_in() ) {
+			$retval = new WP_Error(
+				'bp_rest_authorization_required',
+				__( 'Sorry, you need to be logged in to perform this action.', 'buddypress' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		} elseif ( bp_current_user_can( $capability ) ) {
+			$retval = true;
+		}
+
+		if ( ! is_wp_error( $retval ) ) {
+			$signup = $this->get_signup_object( $request->get_param( 'id' ) );
+
+			if ( empty( $signup ) ) {
 				$retval = new WP_Error(
-					'bp_rest_authorization_required',
-					__( 'Sorry, you need to be logged in to perform this action.', 'buddypress' ),
-					array( 'status' => rest_authorization_required_code() )
+					'bp_rest_invalid_id',
+					__( 'Invalid signup id.', 'buddypress' ),
+					array( 'status' => 404 )
 				);
-			} elseif ( bp_current_user_can( $capability ) ) {
-				$retval = true;
-			}
-
-			if ( ! is_wp_error( $retval ) ) {
-				$signup = $this->get_signup_object( $request->get_param( 'id' ) );
-
-				if ( empty( $signup ) ) {
-					$retval = new WP_Error(
-						'bp_rest_invalid_id',
-						__( 'Invalid signup id.', 'buddypress' ),
-						array( 'status' => 404 )
-					);
-				}
 			}
 		}
 

--- a/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
+++ b/includes/bp-xprofile/classes/class-bp-rest-xprofile-field-groups-endpoint.php
@@ -297,7 +297,17 @@ class BP_REST_XProfile_Field_Groups_Endpoint extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_item_permissions_check( $request ) {
-		$retval = $this->get_items_permissions_check( $request );
+		$retval = new WP_Error(
+			'bp_rest_authorization_required',
+			__( 'Sorry, you are not allowed to perform this action.', 'buddypress' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+
+		if ( bp_current_user_can( 'bp_view', array( 'bp_component' => 'xprofile' ) ) ) {
+			$retval = true;
+		}
 
 		/**
 		 * Filter the XProfile fields groups `get_item` permissions check.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,3 +44,23 @@ require_once WP_TESTS_DIR . '/includes/testcase-rest-controller.php';
 echo "Loading BuddyPress testcases...\n";
 require_once BP_TESTS_DIR . '/includes/testcase.php';
 require_once BP_TESTS_DIR . '/includes/testcase-emails.php';
+
+/**
+ * Set component visibility.
+ *
+ * @param bool $visibility Visibility.
+ */
+function toggle_component_visibility( $visibility = true ) {
+	$visibility = $visibility ? 'members' : 'anyone';
+
+	update_option(
+		'_bp_community_visibility',
+		array(
+			'global'   => $visibility,
+			'activity' => $visibility,
+			'members'  => $visibility,
+			'groups'   => $visibility,
+			'blogs'    => $visibility,
+		)
+	);
+}

--- a/tests/testcases/activity/test-controller.php
+++ b/tests/testcases/activity/test-controller.php
@@ -77,6 +77,21 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$this->bp_factory->activity->create_many( 3 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_multiple_types() {
 		$g1 = $this->bp_factory->group->create( array(
 			'status' => 'public',
@@ -627,6 +642,22 @@ class BP_Test_REST_Activity_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$this->assertNotEmpty( $all_data );
 
 		$this->check_activity_data( $activity, $all_data[0], 'view' );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$activity = $this->endpoint->get_activity_object( $this->activity_id );
+		$this->assertEquals( $this->activity_id, $activity->id );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $activity->id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/testcases/attachments/test-blog-avatar-controller.php
+++ b/tests/testcases/attachments/test-blog-avatar-controller.php
@@ -76,6 +76,20 @@ class BP_Test_REST_Attachments_Blog_Avatar_Endpoint extends WP_Test_REST_Control
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$blog_id = $this->bp_factory->blog->create();
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/avatar', $blog_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_site_icon() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped();

--- a/tests/testcases/attachments/test-group-avatar-controller.php
+++ b/tests/testcases/attachments/test-group-avatar-controller.php
@@ -85,6 +85,19 @@ class BP_Test_REST_Attachments_Group_Avatar_Endpoint extends WP_Test_REST_Contro
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/avatar', $this->group_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_invalid_group_id() {
 		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/avatar', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );

--- a/tests/testcases/attachments/test-group-cover-controller.php
+++ b/tests/testcases/attachments/test-group-cover-controller.php
@@ -66,9 +66,23 @@ class BP_Test_REST_Attachments_Group_Cover_Endpoint extends WP_Test_REST_Control
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/cover', $this->group_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_with_no_image() {
 		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/cover', $this->group_id ) );
 		$response = $this->server->dispatch( $request );
+
 		$this->assertErrorResponse( 'bp_rest_attachments_group_cover_no_image', $response, 500 );
 	}
 

--- a/tests/testcases/attachments/test-member-avatar-controller.php
+++ b/tests/testcases/attachments/test-member-avatar-controller.php
@@ -80,6 +80,19 @@ class BP_Test_REST_Attachments_Member_Avatar_Endpoint extends WP_Test_REST_Contr
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/avatar', $this->user_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_publicly() {
 		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/avatar', $this->user_id ) );
 		$request->set_param( 'context', 'view' );

--- a/tests/testcases/attachments/test-member-cover-controller.php
+++ b/tests/testcases/attachments/test-member-cover-controller.php
@@ -57,6 +57,19 @@ class BP_Test_REST_Attachments_Member_Cover_Endpoint extends WP_Test_REST_Contro
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/cover', $this->user_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_with_no_image() {
 		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/cover', $this->user_id ) );
 		$response = $this->server->dispatch( $request );

--- a/tests/testcases/blogs/test-controller.php
+++ b/tests/testcases/blogs/test-controller.php
@@ -104,6 +104,26 @@ class BP_Test_REST_Blogs_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		$this->skipWithoutMultisite();
+
+		toggle_component_visibility();
+
+		$blog_id = $this->bp_factory->blog->create(
+			array( 'title' => 'The Foo Bar Blog' )
+		);
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $blog_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_invalid_blog_id() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped();

--- a/tests/testcases/groups/test-controller.php
+++ b/tests/testcases/groups/test-controller.php
@@ -70,6 +70,21 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$this->bp_factory->group->create_many( 3 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_including_hidden_groups() {
 		$u  = $this->factory->user->create();
 		$g1 = $this->bp_factory->group->create();
@@ -379,6 +394,21 @@ class BP_Test_REST_Group_Endpoint extends WP_Test_REST_Controller_Testcase {
 		$all_data = $response->get_data();
 
 		$this->check_group_data( $group, $all_data[0], 'view' );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_unauthenticated_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$group = $this->endpoint->get_group_object( $this->group_id );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $group->id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/testcases/groups/test-group-invites-controller.php
+++ b/tests/testcases/groups/test-group-invites-controller.php
@@ -102,6 +102,29 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u1 = $this->factory->user->create();
+		$u2 = $this->factory->user->create();
+		$u3 = $this->factory->user->create();
+		$u4 = $this->factory->user->create();
+
+		$this->populate_group_with_invites( [ $u1, $u2, $u3, $u4 ], $this->group_id );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_query_params( array(
+			'group_id' => $this->group_id,
+		) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_group_invites_cannot_get_items', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_as_group_admin() {
 		$u1 = $this->factory->user->create();
 		$u2 = $this->factory->user->create();
@@ -279,6 +302,28 @@ class BP_Test_REST_Group_Invites_Endpoint extends WP_Test_REST_Controller_Testca
 		$all_data = $response->get_data();
 
 		$this->assertEquals( $u1, $all_data['user_id'] );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u1 = $this->factory->user->create();
+
+		$invite_id = groups_invite_user( array(
+			'user_id'     => $u1,
+			'group_id'    => $this->group_id,
+			'inviter_id'  => $this->user,
+			'send_invite' => 1,
+		) );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $invite_id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/testcases/members/test-controller.php
+++ b/tests/testcases/members/test-controller.php
@@ -100,6 +100,26 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u1 = $this->factory->user->create();
+		$u2 = $this->factory->user->create();
+		$u3 = $this->factory->user->create();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_query_params( array(
+			'user_ids' => [ $u1, $u2, $u3 ],
+		) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_extra() {
 		$u1 = $this->factory->user->create();
 		$u2 = $this->factory->user->create();
@@ -398,6 +418,26 @@ class BP_Test_REST_Members_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->check_get_user_response( $response );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u = $this->factory->user->create();
+
+		// Register and set member types.
+		bp_register_member_type( 'foo' );
+		bp_register_member_type( 'bar' );
+		bp_set_member_type( $u, 'foo' );
+		bp_set_member_type( $u, 'bar', true );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $u ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/testcases/membership/test-group-membership-controller.php
+++ b/tests/testcases/membership/test-group-membership-controller.php
@@ -156,6 +156,28 @@ class BP_Test_REST_Group_Membership_Endpoint extends WP_Test_REST_Controller_Tes
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u1 = $this->factory->user->create();
+		$u2 = $this->factory->user->create();
+
+		$g1 = $this->bp_factory->group->create( array(
+			'creator' => $u1,
+		) );
+
+		$this->populate_group_with_members( [ $u1, $u2 ], $g1 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . $g1 . '/members' );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_paginated_items() {
 		$u1 = $this->factory->user->create();
 		$u2 = $this->factory->user->create();

--- a/tests/testcases/membership/test-group-membership-request-controller.php
+++ b/tests/testcases/membership/test-group-membership-request-controller.php
@@ -105,6 +105,30 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$u2  = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$u3  = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		groups_send_membership_request( array( 'group_id' => $this->group_id, 'user_id' => $u ) );
+		groups_send_membership_request( array( 'group_id' => $this->group_id, 'user_id' => $u2 ) );
+		groups_send_membership_request( array( 'group_id' => $this->group_id, 'user_id' => $u3 ) );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_query_params( array(
+			'group_id' => $this->group_id,
+		) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_as_group_admin() {
 		$u   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$u2  = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -243,6 +267,22 @@ class BP_Test_REST_Group_Membership_Request_Endpoint extends WP_Test_REST_Contro
 
 		$accepted = groups_is_user_member( $u, $this->group_id );
 		$this->assertFalse( $accepted );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$u          = $this->factory->user->create( array( 'role'       => 'subscriber' ) );
+		$request_id = groups_send_membership_request( array( 'group_id' => $this->group_id, 'user_id' => $u ) );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url . '/'. $request_id );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/testcases/xprofile/test-data-controller.php
+++ b/tests/testcases/xprofile/test-data-controller.php
@@ -76,6 +76,20 @@ class BP_Test_REST_XProfile_Data_Endpoint extends WP_Test_REST_Controller_Testca
 	/**
 	 * @group get_item
 	 */
+	public function test_get_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		xprofile_set_field_data( $this->field_id, $this->user, 'foo' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '%d/data/%d', $this->field_id, $this->user ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_item
+	 */
 	public function test_get_item_hidden_for_user() {
 		$f = $this->bp_factory->xprofile_field->create( array( 'field_group_id' => $this->group_id ) );
 		xprofile_set_field_data( $f, $this->user, 'bar' );

--- a/tests/testcases/xprofile/test-field-controller.php
+++ b/tests/testcases/xprofile/test-field-controller.php
@@ -95,6 +95,20 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 	/**
 	 * @group get_items
 	 */
+	public function test_public_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$this->bp_factory->xprofile_field->create_many( 5, [ 'field_group_id' => $this->group_id ] );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_include_groups() {
 		$g1 = $this->bp_factory->xprofile_group->create();
 		$g2 = $this->bp_factory->xprofile_group->create();
@@ -158,6 +172,21 @@ class BP_Test_REST_XProfile_Fields_Endpoint extends WP_Test_REST_Controller_Test
 		$this->assertNotEmpty( $all_data );
 
 		$this->check_field_data( $field, $all_data[0] );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_public_item_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$field = $this->endpoint->get_xprofile_field_object( $this->field_id );
+		$this->assertEquals( $this->field_id, $field->id );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $field->id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**

--- a/tests/testcases/xprofile/test-group-controller.php
+++ b/tests/testcases/xprofile/test-group-controller.php
@@ -73,6 +73,21 @@ class BP_Test_REST_XProfile_Groups_Endpoint extends WP_Test_REST_Controller_Test
 	/**
 	 * @group get_items
 	 */
+	public function test_get_items_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$this->bp_factory->xprofile_group->create_many( 5 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint_url );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 * @group get_items
+	 */
 	public function test_get_items_include_groups() {
 		$this->bp->set_current_user( $this->user );
 
@@ -142,6 +157,22 @@ class BP_Test_REST_XProfile_Groups_Endpoint extends WP_Test_REST_Controller_Test
 		$this->assertNotEmpty( $all_data );
 
 		$this->check_group_data( $field_group, $all_data[0], 'view', $response->get_links() );
+	}
+
+	/**
+	 * @group get_item
+	 */
+	public function test_get_item_publicly_with_support_for_the_community_visibility() {
+		toggle_component_visibility();
+
+		$field_group = $this->endpoint->get_xprofile_field_group_object( $this->group_id );
+		$this->assertEquals( $this->group_id, $field_group->id );
+
+		$request = new WP_REST_Request( 'GET', sprintf( $this->endpoint_url . '/%d', $field_group->id ) );
+		$request->set_param( 'context', 'view' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'bp_rest_authorization_required', $response, rest_authorization_required_code() );
 	}
 
 	/**


### PR DESCRIPTION
- fixes #496 
- adds unit tests
- add support for missing components, i.e., activity