### PR TITLE
Use `groups_$action_member()` function to manage memberships

### DIFF
--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -395,10 +395,9 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 		$action       = $request->get_param( 'action' );
 		$role         = $request->get_param( 'role' );
 		$group_id     = $group->id;
-		$group_member = new BP_Groups_Member( $user->ID, $group_id );
 
 		if ( 'promote' === $action ) {
-			if ( ! $group_member->promote( $role ) ) {
+			if ( ! groups_promote_member( $user->ID, $group_id, $role, bp_loggedin_user_id() ) ) {
 				return new WP_Error(
 					'bp_rest_group_member_failed_to_promote',
 					__( 'Could not promote member.', 'buddypress' ),
@@ -408,7 +407,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 				);
 			}
 		} elseif ( 'demote' === $action && 'member' !== $role ) {
-			if ( ! $group_member->promote( $role ) ) {
+			if ( ! groups_promote_member( $user->ID, $group_id, $role, bp_loggedin_user_id() ) ) {
 				return new WP_Error(
 					'bp_rest_group_member_failed_to_demote',
 					__( 'Could not demote member.', 'buddypress' ),
@@ -418,7 +417,7 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 				);
 			}
 		} elseif ( in_array( $action, array( 'demote', 'ban', 'unban' ), true ) ) {
-			if ( ! $group_member->$action() ) {
+			if ( ! call_user_func( 'groups_' . $action . '_member', $user->ID, $group_id, bp_loggedin_user_id() ) ) {
 				$messages = array(
 					'demote' => __( 'Could not demote member from the group.', 'buddypress' ),
 					'ban'    => __( 'Could not ban member from the group.', 'buddypress' ),
@@ -434,6 +433,9 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 				);
 			}
 		}
+
+		// Get updated group member.
+		$group_member = new BP_Groups_Member( $user->ID, $group_id );
 
 		// Setting context.
 		$request->set_param( 'context', 'edit' );

--- a/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
+++ b/includes/bp-groups/classes/class-bp-rest-group-membership-endpoint.php
@@ -390,11 +390,11 @@ class BP_REST_Group_Membership_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function update_item( $request ) {
-		$user         = bp_rest_get_user( $request->get_param( 'user_id' ) );
-		$group        = $this->groups_endpoint->get_group_object( $request->get_param( 'group_id' ) );
-		$action       = $request->get_param( 'action' );
-		$role         = $request->get_param( 'role' );
-		$group_id     = $group->id;
+		$user     = bp_rest_get_user( $request->get_param( 'user_id' ) );
+		$group    = $this->groups_endpoint->get_group_object( $request->get_param( 'group_id' ) );
+		$action   = $request->get_param( 'action' );
+		$role     = $request->get_param( 'role' );
+		$group_id = $group->id;
 
 		if ( 'promote' === $action ) {
 			if ( ! groups_promote_member( $user->ID, $group_id, $role, bp_loggedin_user_id() ) ) {


### PR DESCRIPTION
Working on https://buddypress.trac.wordpress.org/ticket/9158 I realized using `BP_Groups_Member->$action()` methods was not a great idea. We really need to use `groups_$action_member()` functions instead.

In https://github.com/buddypress/buddypress/pull/293 I'm updating these functions so that it's possible to use them from the REST API (the `bp_is_item_admin()` checks were restricting their use to the Web).

This makes sure cache is cleared, group activities are removed when needed etc...
See: https://github.com/buddypress/buddypress/blob/edd1d2e33a2a4d3ace8216e06ba846a36f452b88/src/bp-groups/bp-groups-cache.php#L391|L394